### PR TITLE
Add Fluss config and split translation seam

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <arrow.version>18.3.0</arrow.version>
         <flink.version>2.2.1</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
+        <fluss.version>0.9.1-incubating</fluss.version>
         <!-- Matches the protobuf runtime Flink's protobuf format generates code against. -->
         <protobuf.version>4.32.1</protobuf.version>
         <!-- Native build: debug by default for a fast correctness loop. The `bench` profile flips
@@ -221,6 +222,14 @@
             <artifactId>kafka</artifactId>
             <version>1.21.4</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Public Fluss source split/config classes used to hand JVM-coordinated assignments to native code.
+             The connector stays provided, like Flink, so StreamFusion does not bundle a Fluss runtime. -->
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-flink-2.2</artifactId>
+            <version>${fluss.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslator.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslator.java
@@ -1,0 +1,241 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Translates the Fluss Java/Flink table options that belong to the Fluss client into the field names
+ * used by {@code fluss-rs::Config}. Flink source-coordination options are deliberately kept out of
+ * the native config: those decide startup offsets, partition discovery, split assignment, and
+ * checkpoints on the JVM side.
+ */
+public final class FlussConfigTranslator {
+
+  private FlussConfigTranslator() {}
+
+  public static final class Result {
+    private final Map<String, String> config;
+    private final Map<String, String> coordinationOptions;
+    private final String fallbackReason;
+
+    private Result(
+        Map<String, String> config, Map<String, String> coordinationOptions, String fallbackReason) {
+      this.config = config;
+      this.coordinationOptions = coordinationOptions;
+      this.fallbackReason = fallbackReason;
+    }
+
+    static Result translated(Map<String, String> config, Map<String, String> coordinationOptions) {
+      return new Result(config, coordinationOptions, null);
+    }
+
+    static Result fallback(String reason) {
+      return new Result(null, Map.of(), reason);
+    }
+
+    public boolean isTranslated() {
+      return config != null;
+    }
+
+    public Map<String, String> config() {
+      return config;
+    }
+
+    public Map<String, String> coordinationOptions() {
+      return coordinationOptions;
+    }
+
+    public Optional<String> fallbackReason() {
+      return Optional.ofNullable(fallbackReason);
+    }
+  }
+
+  private static final Map<String, String> DIRECT =
+      Map.ofEntries(
+          Map.entry("bootstrap.servers", "bootstrap_servers"),
+          Map.entry("client.scanner.log.max-poll-records", "scanner_log_max_poll_records"),
+          Map.entry("client.scanner.remote-log.prefetch-num", "scanner_remote_log_prefetch_num"),
+          Map.entry("client.remote-file.download-thread-num", "remote_file_download_thread_num"),
+          Map.entry("client.writer.dynamic-batch-size.enabled", "writer_dynamic_batch_size_enabled"),
+          Map.entry("client.writer.bucket.no-key-assigner", "writer_bucket_no_key_assigner"),
+          Map.entry("client.writer.acks", "writer_acks"),
+          Map.entry("client.writer.retries", "writer_retries"),
+          Map.entry("client.writer.enable-idempotence", "writer_enable_idempotence"),
+          Map.entry(
+              "client.writer.max-inflight-requests-per-bucket",
+              "writer_max_inflight_requests_per_bucket"),
+          Map.entry("client.lookup.queue-size", "lookup_queue_size"),
+          Map.entry("client.lookup.max-batch-size", "lookup_max_batch_size"),
+          Map.entry("client.lookup.max-inflight-requests", "lookup_max_inflight_requests"),
+          Map.entry("client.lookup.max-retries", "lookup_max_retries"),
+          Map.entry("client.security.protocol", "security_protocol"),
+          Map.entry("client.security.sasl.mechanism", "security_sasl_mechanism"),
+          Map.entry("client.security.sasl.username", "security_sasl_username"),
+          Map.entry("client.security.sasl.password", "security_sasl_password"));
+
+  private static final Map<String, String> MEMORY =
+      Map.ofEntries(
+          Map.entry("client.scanner.log.fetch.max-bytes", "scanner_log_fetch_max_bytes"),
+          Map.entry(
+              "client.scanner.log.fetch.max-bytes-for-bucket",
+              "scanner_log_fetch_max_bytes_for_bucket"),
+          Map.entry("client.scanner.log.fetch.min-bytes", "scanner_log_fetch_min_bytes"),
+          Map.entry("client.writer.request-max-size", "writer_request_max_size"),
+          Map.entry("client.writer.batch-size", "writer_batch_size"),
+          Map.entry("client.writer.buffer.memory-size", "writer_buffer_memory_size"));
+
+  private static final Map<String, String> DURATION =
+      Map.ofEntries(
+          Map.entry("client.connect-timeout", "connect_timeout_ms"),
+          Map.entry("client.scanner.log.fetch.wait-max-time", "scanner_log_fetch_wait_max_time_ms"),
+          Map.entry("client.writer.batch-timeout", "writer_batch_timeout_ms"),
+          Map.entry("client.writer.buffer.wait-timeout", "writer_buffer_wait_timeout_ms"),
+          Map.entry("client.lookup.batch-timeout", "lookup_batch_timeout_ms"));
+
+  private static final String[] COORDINATION = {
+    "scan.startup.mode",
+    "scan.startup.timestamp",
+    "scan.partition.discovery.interval",
+    "scan.kv.snapshot.lease.id",
+    "scan.kv.snapshot.lease.duration"
+  };
+
+  private static final String[] NO_RUST_CONFIG = {
+    "client.id",
+    "client.request-timeout",
+    "client.scanner.log.check-crc",
+    "client.scanner.io.tmpdir",
+    "client.metrics.enabled",
+    "client.security.sasl.jaas.config"
+  };
+
+  /** Translates known client options, or returns a fallback reason for a setting not safely mirrored. */
+  public static Result translate(Map<String, String> options) {
+    Map<String, String> out = new LinkedHashMap<>();
+    Map<String, String> coordination = new LinkedHashMap<>();
+
+    for (String key : COORDINATION) {
+      if (options.containsKey(key)) {
+        coordination.put(key, options.get(key));
+      }
+    }
+
+    for (String key : NO_RUST_CONFIG) {
+      if (options.containsKey(key)) {
+        return Result.fallback("no fluss-rs Config field for " + key);
+      }
+    }
+    for (String key : options.keySet()) {
+      if (key.startsWith("client.") && !isKnownClientOption(key)) {
+        return Result.fallback("unmapped Fluss client option " + key);
+      }
+    }
+
+    for (Map.Entry<String, String> entry : DIRECT.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), translateDirect(entry.getKey(), options.get(entry.getKey())));
+      }
+    }
+    for (Map.Entry<String, String> entry : MEMORY.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), Long.toString(parseMemoryBytes(options.get(entry.getKey()))));
+      }
+    }
+    for (Map.Entry<String, String> entry : DURATION.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), Long.toString(parseDurationMillis(options.get(entry.getKey()))));
+      }
+    }
+
+    String protocol = out.get("security_protocol");
+    String mechanism = out.getOrDefault("security_sasl_mechanism", "PLAIN");
+    if (protocol != null
+        && protocol.equalsIgnoreCase("sasl")
+        && !mechanism.equalsIgnoreCase("PLAIN")) {
+      return Result.fallback("fluss-rs currently supports only PLAIN SASL");
+    }
+
+    return Result.translated(out, coordination);
+  }
+
+  private static boolean isKnownClientOption(String key) {
+    return DIRECT.containsKey(key)
+        || MEMORY.containsKey(key)
+        || DURATION.containsKey(key)
+        || contains(NO_RUST_CONFIG, key);
+  }
+
+  private static boolean contains(String[] values, String target) {
+    for (String value : values) {
+      if (value.equals(target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String translateDirect(String javaKey, String value) {
+    if ("client.writer.bucket.no-key-assigner".equals(javaKey)) {
+      return value.trim().toLowerCase().replace('-', '_');
+    }
+    return value;
+  }
+
+  private static long parseMemoryBytes(String value) {
+    String normalized = value.trim().toLowerCase().replaceAll("\\s+", "");
+    long multiplier = 1;
+    String number = normalized;
+    if (normalized.endsWith("bytes")) {
+      number = normalized.substring(0, normalized.length() - "bytes".length());
+    } else if (normalized.endsWith("byte")) {
+      number = normalized.substring(0, normalized.length() - "byte".length());
+    } else if (normalized.endsWith("kib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L;
+    } else if (normalized.endsWith("kb") || normalized.endsWith("k")) {
+      number = normalized.replaceAll("k[b]?$", "");
+      multiplier = 1024L;
+    } else if (normalized.endsWith("mib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L * 1024L;
+    } else if (normalized.endsWith("mb") || normalized.endsWith("m")) {
+      number = normalized.replaceAll("m[b]?$", "");
+      multiplier = 1024L * 1024L;
+    } else if (normalized.endsWith("gib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L * 1024L * 1024L;
+    } else if (normalized.endsWith("gb") || normalized.endsWith("g")) {
+      number = normalized.replaceAll("g[b]?$", "");
+      multiplier = 1024L * 1024L * 1024L;
+    } else if (normalized.endsWith("b")) {
+      number = normalized.substring(0, normalized.length() - 1);
+    }
+    return Long.parseLong(number) * multiplier;
+  }
+
+  private static long parseDurationMillis(String value) {
+    String trimmed = value.trim();
+    if (trimmed.toUpperCase().startsWith("P")) {
+      return Duration.parse(trimmed).toMillis();
+    }
+    String normalized = trimmed.toLowerCase().replaceAll("\\s+", "");
+    if (normalized.endsWith("ms")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 2));
+    }
+    if (normalized.endsWith("s")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 1000L;
+    }
+    if (normalized.endsWith("min")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 3)) * 60_000L;
+    }
+    if (normalized.endsWith("m")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 60_000L;
+    }
+    if (normalized.endsWith("h")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 3_600_000L;
+    }
+    return Long.parseLong(normalized);
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslator.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslator.java
@@ -1,0 +1,32 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import org.apache.fluss.flink.source.split.LogSplit;
+import org.apache.fluss.flink.source.split.SourceSplitBase;
+import org.apache.fluss.metadata.TableBucket;
+
+/** Converts Fluss's public source splits into the minimal native log-reader assignment. */
+public final class FlussSplitTranslator {
+
+  private FlussSplitTranslator() {}
+
+  public static boolean isNativeLogSplit(SourceSplitBase split) {
+    return split.isLogSplit();
+  }
+
+  public static NativeFlussLogSplit translateLogSplit(SourceSplitBase split) {
+    if (!split.isLogSplit()) {
+      throw new IllegalArgumentException(
+          "native Fluss proof path only accepts log splits, got " + split.getClass().getSimpleName());
+    }
+    LogSplit log = split.asLogSplit();
+    TableBucket bucket = log.getTableBucket();
+    return new NativeFlussLogSplit(
+        log.splitId(),
+        bucket.getTableId(),
+        bucket.getPartitionId(),
+        log.getPartitionName(),
+        bucket.getBucket(),
+        log.getStartingOffset(),
+        log.getStoppingOffset().orElse(null));
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussLogSplit.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussLogSplit.java
@@ -1,0 +1,60 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import java.util.OptionalLong;
+
+/** Concrete log-table split assignment passed from Flink's Fluss enumerator to the native reader. */
+public final class NativeFlussLogSplit {
+
+  private final String splitId;
+  private final long tableId;
+  private final Long partitionId;
+  private final String partitionName;
+  private final int bucket;
+  private final long startingOffset;
+  private final Long stoppingOffset;
+
+  NativeFlussLogSplit(
+      String splitId,
+      long tableId,
+      Long partitionId,
+      String partitionName,
+      int bucket,
+      long startingOffset,
+      Long stoppingOffset) {
+    this.splitId = splitId;
+    this.tableId = tableId;
+    this.partitionId = partitionId;
+    this.partitionName = partitionName;
+    this.bucket = bucket;
+    this.startingOffset = startingOffset;
+    this.stoppingOffset = stoppingOffset;
+  }
+
+  public String splitId() {
+    return splitId;
+  }
+
+  public long tableId() {
+    return tableId;
+  }
+
+  public OptionalLong partitionId() {
+    return partitionId == null ? OptionalLong.empty() : OptionalLong.of(partitionId);
+  }
+
+  public String partitionName() {
+    return partitionName;
+  }
+
+  public int bucket() {
+    return bucket;
+  }
+
+  public long startingOffset() {
+    return startingOffset;
+  }
+
+  public OptionalLong stoppingOffset() {
+    return stoppingOffset == null ? OptionalLong.empty() : OptionalLong.of(stoppingOffset);
+  }
+}

--- a/src/test/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslatorTest.java
+++ b/src/test/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslatorTest.java
@@ -1,0 +1,94 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FlussConfigTranslatorTest {
+
+  private static Map<String, String> translated(Map<String, String> options) {
+    FlussConfigTranslator.Result result = FlussConfigTranslator.translate(options);
+    assertTrue(
+        result.isTranslated(), () -> "expected translation, got " + result.fallbackReason());
+    return result.config();
+  }
+
+  private static String fallback(Map<String, String> options) {
+    FlussConfigTranslator.Result result = FlussConfigTranslator.translate(options);
+    assertFalse(result.isTranslated(), "expected fallback, got translation");
+    return result.fallbackReason().orElseThrow();
+  }
+
+  @Test
+  void mapsScannerClientKnobsToRustConfigFields() {
+    Map<String, String> config =
+        translated(
+            Map.of(
+                "bootstrap.servers", "localhost:9123",
+                "client.scanner.log.max-poll-records", "2048",
+                "client.scanner.log.fetch.max-bytes", "16 mb",
+                "client.scanner.log.fetch.max-bytes-for-bucket", "1 mb",
+                "client.scanner.log.fetch.min-bytes", "1 bytes",
+                "client.scanner.log.fetch.wait-max-time", "PT0.5S",
+                "client.scanner.remote-log.prefetch-num", "8",
+                "client.remote-file.download-thread-num", "4"));
+
+    assertEquals("localhost:9123", config.get("bootstrap_servers"));
+    assertEquals("2048", config.get("scanner_log_max_poll_records"));
+    assertEquals("16777216", config.get("scanner_log_fetch_max_bytes"));
+    assertEquals("1048576", config.get("scanner_log_fetch_max_bytes_for_bucket"));
+    assertEquals("1", config.get("scanner_log_fetch_min_bytes"));
+    assertEquals("500", config.get("scanner_log_fetch_wait_max_time_ms"));
+    assertEquals("8", config.get("scanner_remote_log_prefetch_num"));
+    assertEquals("4", config.get("remote_file_download_thread_num"));
+  }
+
+  @Test
+  void keepsFlinkCoordinationOptionsOutOfNativeConfig() {
+    FlussConfigTranslator.Result result =
+        FlussConfigTranslator.translate(
+            Map.of(
+                "bootstrap.servers", "localhost:9123",
+                "scan.startup.mode", "earliest",
+                "scan.partition.discovery.interval", "1 min"));
+
+    assertTrue(result.isTranslated());
+    assertFalse(result.config().containsKey("scan.startup.mode"));
+    assertFalse(result.config().containsKey("scan.partition.discovery.interval"));
+    assertEquals("earliest", result.coordinationOptions().get("scan.startup.mode"));
+    assertEquals("1 min", result.coordinationOptions().get("scan.partition.discovery.interval"));
+  }
+
+  @Test
+  void mapsBasicPlainSaslButRejectsUnsupportedMechanism() {
+    Map<String, String> config =
+        translated(
+            Map.of(
+                "client.security.protocol", "sasl",
+                "client.security.sasl.mechanism", "PLAIN",
+                "client.security.sasl.username", "alice",
+                "client.security.sasl.password", "secret"));
+
+    assertEquals("sasl", config.get("security_protocol"));
+    assertEquals("PLAIN", config.get("security_sasl_mechanism"));
+    assertEquals("alice", config.get("security_sasl_username"));
+    assertEquals("secret", config.get("security_sasl_password"));
+    assertTrue(
+        fallback(
+                Map.of(
+                    "client.security.protocol", "sasl",
+                    "client.security.sasl.mechanism", "SCRAM-SHA-256"))
+            .contains("PLAIN"));
+  }
+
+  @Test
+  void fallsBackOnClientOptionsNotRepresentedInFlussRsConfig() {
+    assertTrue(fallback(Map.of("client.request-timeout", "30 s")).contains("request-timeout"));
+    assertTrue(fallback(Map.of("client.scanner.log.check-crc", "true")).contains("check-crc"));
+    assertTrue(fallback(Map.of("client.security.sasl.jaas.config", "x")).contains("jaas"));
+    assertTrue(fallback(Map.of("client.scanner.future-option", "true")).contains("unmapped"));
+  }
+}

--- a/src/test/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslatorTest.java
+++ b/src/test/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslatorTest.java
@@ -1,0 +1,51 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.fluss.flink.source.split.HybridSnapshotLogSplit;
+import org.apache.fluss.flink.source.split.LogSplit;
+import org.apache.fluss.metadata.TableBucket;
+import org.junit.jupiter.api.Test;
+
+class FlussSplitTranslatorTest {
+
+  @Test
+  void extractsNativeAssignmentFromNonPartitionedLogSplit() {
+    LogSplit split = new LogSplit(new TableBucket(7L, 2), null, 11L, 42L);
+
+    NativeFlussLogSplit nativeSplit = FlussSplitTranslator.translateLogSplit(split);
+
+    assertEquals(split.splitId(), nativeSplit.splitId());
+    assertEquals(7L, nativeSplit.tableId());
+    assertFalse(nativeSplit.partitionId().isPresent());
+    assertEquals(2, nativeSplit.bucket());
+    assertEquals(11L, nativeSplit.startingOffset());
+    assertEquals(42L, nativeSplit.stoppingOffset().orElseThrow());
+  }
+
+  @Test
+  void extractsNativeAssignmentFromPartitionedLogSplit() {
+    LogSplit split = new LogSplit(new TableBucket(7L, 99L, 3), "dt=2026-07-04", 5L);
+
+    NativeFlussLogSplit nativeSplit = FlussSplitTranslator.translateLogSplit(split);
+
+    assertEquals(7L, nativeSplit.tableId());
+    assertEquals(99L, nativeSplit.partitionId().orElseThrow());
+    assertEquals("dt=2026-07-04", nativeSplit.partitionName());
+    assertEquals(3, nativeSplit.bucket());
+    assertEquals(5L, nativeSplit.startingOffset());
+    assertFalse(nativeSplit.stoppingOffset().isPresent());
+  }
+
+  @Test
+  void rejectsHybridSnapshotLogSplitForTheLogTableProofPath() {
+    HybridSnapshotLogSplit split =
+        new HybridSnapshotLogSplit(new TableBucket(7L, 2), null, 123L, 4L);
+
+    assertFalse(FlussSplitTranslator.isNativeLogSplit(split));
+    assertThrows(IllegalArgumentException.class, () -> FlussSplitTranslator.translateLogSplit(split));
+  }
+}


### PR DESCRIPTION
## Summary
- add a Java-side Fluss config translator for the native reader handoff
- separate JVM/Flink coordination options from native client config
- add a minimal native log split DTO plus translator from Fluss source splits
- fail closed on Fluss client options that do not map cleanly

## Scope
- no native/Cargo changes
- no benchmark or docs changes
- Arrow dependency state is unchanged in Rust; Maven resolves only the existing Arrow 18.3.0 JVM artifacts

## Tests
- `MAVEN_DIR=/tmp/apache-maven-3.9.10 JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH="/tmp/fake-cargo:$MAVEN_DIR/bin:$PATH" mvn -B -ntp -Dnative.profile=release -Dtest=FlussConfigTranslatorTest,FlussSplitTranslatorTest test`
- `MAVEN_DIR=/tmp/apache-maven-3.9.10 JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH="$MAVEN_DIR/bin:$PATH" mvn -B -ntp dependency:tree -Dverbose -Dincludes=org.apache.arrow`