### PR TITLE
Add native Fluss source shell

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -83,6 +83,9 @@ libmimalloc-sys = { version = "0.1", optional = true }
 default = ["kafka"]
 kafka = ["dep:rdkafka"]
 kafka-bench = ["kafka"]
+# Placeholder gate for the stacked Fluss source work. The fluss-rs dependency is added only after
+# its Arrow version is aligned with StreamFusion's native Arrow stack.
+fluss = []
 # Rebind the C allocator to mimalloc for everything linked into THIS library (librdkafka included),
 # via link-time symbol aliases emitted by build.rs. Library-scoped: the hosting JVM process keeps
 # its own allocator, so this carries none of the risk of a process-wide malloc override (a zone-swap

--- a/native/src/fluss.rs
+++ b/native/src/fluss.rs
@@ -1,0 +1,11 @@
+use crate::*;
+
+/// Feature probe for the JVM planner. The actual fluss-rs reader lands in a later slice once
+/// StreamFusion and fluss-rs are on the same Arrow version.
+#[no_mangle]
+pub extern "system" fn Java_io_github_jordepic_streamfusion_Native_flussFeatureBuilt<'local>(
+    _env: JNIEnv<'local>,
+    _class: JClass<'local>,
+) -> jboolean {
+    false as jboolean
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -62,6 +62,7 @@ mod exchange;
 mod expr;
 mod files;
 mod flatten;
+mod fluss;
 mod formats;
 mod group_agg;
 mod interval_join;

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <arrow.version>18.3.0</arrow.version>
         <flink.version>2.2.1</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
+        <fluss.version>0.9.1-incubating</fluss.version>
         <!-- Matches the protobuf runtime Flink's protobuf format generates code against. -->
         <protobuf.version>4.32.1</protobuf.version>
         <!-- Native build: debug by default for a fast correctness loop. The `bench` profile flips
@@ -221,6 +222,14 @@
             <artifactId>kafka</artifactId>
             <version>1.21.4</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Public Fluss source split/config classes used to hand JVM-coordinated assignments to native code.
+             The connector stays provided, like Flink, so StreamFusion does not bundle a Fluss runtime. -->
+        <dependency>
+            <groupId>org.apache.fluss</groupId>
+            <artifactId>fluss-flink-2.2</artifactId>
+            <version>${fluss.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/github/jordepic/streamfusion/Native.java
+++ b/src/main/java/io/github/jordepic/streamfusion/Native.java
@@ -922,6 +922,70 @@ public final class Native {
   public static native boolean kafkaFeatureBuilt();
 
   /**
+   * Whether the loaded native library was built with the {@code fluss} cargo feature. Until the
+   * fluss-rs reader is linked in, the native probe returns false so planner wiring can fall back.
+   */
+  public static native boolean flussFeatureBuilt();
+
+  /**
+   * Opens a native Fluss log-table reader for one source subtask. Fluss' JVM enumerator assigns
+   * splits; this reader subscribes those concrete table buckets through fluss-rs and exports Arrow
+   * batches.
+   *
+   * @param configKeys translated fluss-rs config field names
+   * @param configValues values index-aligned with {@code configKeys}
+   * @param databaseName Fluss database name
+   * @param tableName Fluss table name
+   * @param projectedFields projected column indices, or empty for all columns
+   */
+  public static native long openFlussReader(
+      String[] configKeys,
+      String[] configValues,
+      String databaseName,
+      String tableName,
+      int[] projectedFields);
+
+  /**
+   * Adds assigned log splits to the native Fluss reader. Index-aligned arrays; {@code Long.MIN_VALUE}
+   * marks a non-partitioned split or no stopping offset.
+   */
+  public static native void assignFlussSplits(
+      long handle,
+      String[] splitIds,
+      long[] tableIds,
+      long[] partitionIds,
+      long[] buckets,
+      long[] startOffsets,
+      long[] stoppingOffsets);
+
+  /**
+   * Removes finished Fluss splits from the native scanner's subscriptions so bounded tails don't keep
+   * polling completed buckets.
+   */
+  public static native void unassignFlussSplits(
+      long handle, long[] tableIds, long[] partitionIds, long[] buckets);
+
+  /**
+   * Polls one Fluss scanner cycle and returns the number of per-split Arrow batches ready to drain.
+   */
+  public static native int pollFlussBatch(long handle, long timeoutMillis);
+
+  /**
+   * Drains one pending Fluss batch, writes {@code [nextOffset]} into {@code splitMeta}, writes the
+   * split id into {@code outSplitId[0]}, exports Arrow into the consumer C structs, and returns the
+   * row count. Call it {@link #pollFlussBatch}'s return-value times.
+   */
+  public static native int drainFlussSplit(
+      long handle,
+      long[] splitMeta,
+      String[] outSplitId,
+      long outArrayAddress,
+      long outSchemaAddress);
+
+  /** Releases a native Fluss reader and closes its fluss-rs connection. */
+  public static native void closeFlussReader(long handle);
+
+  /**
    * Opens a native Kafka split reader for one subtask and returns an opaque handle, released with
    * {@link #closeKafkaConsumer}. One rdkafka consumer multiplexes the subtask's partitions; splits are
    * added later with {@link #assignKafkaSplits} as the enumerator assigns them. The reader manually

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslator.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslator.java
@@ -1,0 +1,241 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Translates the Fluss Java/Flink table options that belong to the Fluss client into the field names
+ * used by {@code fluss-rs::Config}. Flink source-coordination options are deliberately kept out of
+ * the native config: those decide startup offsets, partition discovery, split assignment, and
+ * checkpoints on the JVM side.
+ */
+public final class FlussConfigTranslator {
+
+  private FlussConfigTranslator() {}
+
+  public static final class Result {
+    private final Map<String, String> config;
+    private final Map<String, String> coordinationOptions;
+    private final String fallbackReason;
+
+    private Result(
+        Map<String, String> config, Map<String, String> coordinationOptions, String fallbackReason) {
+      this.config = config;
+      this.coordinationOptions = coordinationOptions;
+      this.fallbackReason = fallbackReason;
+    }
+
+    static Result translated(Map<String, String> config, Map<String, String> coordinationOptions) {
+      return new Result(config, coordinationOptions, null);
+    }
+
+    static Result fallback(String reason) {
+      return new Result(null, Map.of(), reason);
+    }
+
+    public boolean isTranslated() {
+      return config != null;
+    }
+
+    public Map<String, String> config() {
+      return config;
+    }
+
+    public Map<String, String> coordinationOptions() {
+      return coordinationOptions;
+    }
+
+    public Optional<String> fallbackReason() {
+      return Optional.ofNullable(fallbackReason);
+    }
+  }
+
+  private static final Map<String, String> DIRECT =
+      Map.ofEntries(
+          Map.entry("bootstrap.servers", "bootstrap_servers"),
+          Map.entry("client.scanner.log.max-poll-records", "scanner_log_max_poll_records"),
+          Map.entry("client.scanner.remote-log.prefetch-num", "scanner_remote_log_prefetch_num"),
+          Map.entry("client.remote-file.download-thread-num", "remote_file_download_thread_num"),
+          Map.entry("client.writer.dynamic-batch-size.enabled", "writer_dynamic_batch_size_enabled"),
+          Map.entry("client.writer.bucket.no-key-assigner", "writer_bucket_no_key_assigner"),
+          Map.entry("client.writer.acks", "writer_acks"),
+          Map.entry("client.writer.retries", "writer_retries"),
+          Map.entry("client.writer.enable-idempotence", "writer_enable_idempotence"),
+          Map.entry(
+              "client.writer.max-inflight-requests-per-bucket",
+              "writer_max_inflight_requests_per_bucket"),
+          Map.entry("client.lookup.queue-size", "lookup_queue_size"),
+          Map.entry("client.lookup.max-batch-size", "lookup_max_batch_size"),
+          Map.entry("client.lookup.max-inflight-requests", "lookup_max_inflight_requests"),
+          Map.entry("client.lookup.max-retries", "lookup_max_retries"),
+          Map.entry("client.security.protocol", "security_protocol"),
+          Map.entry("client.security.sasl.mechanism", "security_sasl_mechanism"),
+          Map.entry("client.security.sasl.username", "security_sasl_username"),
+          Map.entry("client.security.sasl.password", "security_sasl_password"));
+
+  private static final Map<String, String> MEMORY =
+      Map.ofEntries(
+          Map.entry("client.scanner.log.fetch.max-bytes", "scanner_log_fetch_max_bytes"),
+          Map.entry(
+              "client.scanner.log.fetch.max-bytes-for-bucket",
+              "scanner_log_fetch_max_bytes_for_bucket"),
+          Map.entry("client.scanner.log.fetch.min-bytes", "scanner_log_fetch_min_bytes"),
+          Map.entry("client.writer.request-max-size", "writer_request_max_size"),
+          Map.entry("client.writer.batch-size", "writer_batch_size"),
+          Map.entry("client.writer.buffer.memory-size", "writer_buffer_memory_size"));
+
+  private static final Map<String, String> DURATION =
+      Map.ofEntries(
+          Map.entry("client.connect-timeout", "connect_timeout_ms"),
+          Map.entry("client.scanner.log.fetch.wait-max-time", "scanner_log_fetch_wait_max_time_ms"),
+          Map.entry("client.writer.batch-timeout", "writer_batch_timeout_ms"),
+          Map.entry("client.writer.buffer.wait-timeout", "writer_buffer_wait_timeout_ms"),
+          Map.entry("client.lookup.batch-timeout", "lookup_batch_timeout_ms"));
+
+  private static final String[] COORDINATION = {
+    "scan.startup.mode",
+    "scan.startup.timestamp",
+    "scan.partition.discovery.interval",
+    "scan.kv.snapshot.lease.id",
+    "scan.kv.snapshot.lease.duration"
+  };
+
+  private static final String[] NO_RUST_CONFIG = {
+    "client.id",
+    "client.request-timeout",
+    "client.scanner.log.check-crc",
+    "client.scanner.io.tmpdir",
+    "client.metrics.enabled",
+    "client.security.sasl.jaas.config"
+  };
+
+  /** Translates known client options, or returns a fallback reason for a setting not safely mirrored. */
+  public static Result translate(Map<String, String> options) {
+    Map<String, String> out = new LinkedHashMap<>();
+    Map<String, String> coordination = new LinkedHashMap<>();
+
+    for (String key : COORDINATION) {
+      if (options.containsKey(key)) {
+        coordination.put(key, options.get(key));
+      }
+    }
+
+    for (String key : NO_RUST_CONFIG) {
+      if (options.containsKey(key)) {
+        return Result.fallback("no fluss-rs Config field for " + key);
+      }
+    }
+    for (String key : options.keySet()) {
+      if (key.startsWith("client.") && !isKnownClientOption(key)) {
+        return Result.fallback("unmapped Fluss client option " + key);
+      }
+    }
+
+    for (Map.Entry<String, String> entry : DIRECT.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), translateDirect(entry.getKey(), options.get(entry.getKey())));
+      }
+    }
+    for (Map.Entry<String, String> entry : MEMORY.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), Long.toString(parseMemoryBytes(options.get(entry.getKey()))));
+      }
+    }
+    for (Map.Entry<String, String> entry : DURATION.entrySet()) {
+      if (options.containsKey(entry.getKey())) {
+        out.put(entry.getValue(), Long.toString(parseDurationMillis(options.get(entry.getKey()))));
+      }
+    }
+
+    String protocol = out.get("security_protocol");
+    String mechanism = out.getOrDefault("security_sasl_mechanism", "PLAIN");
+    if (protocol != null
+        && protocol.equalsIgnoreCase("sasl")
+        && !mechanism.equalsIgnoreCase("PLAIN")) {
+      return Result.fallback("fluss-rs currently supports only PLAIN SASL");
+    }
+
+    return Result.translated(out, coordination);
+  }
+
+  private static boolean isKnownClientOption(String key) {
+    return DIRECT.containsKey(key)
+        || MEMORY.containsKey(key)
+        || DURATION.containsKey(key)
+        || contains(NO_RUST_CONFIG, key);
+  }
+
+  private static boolean contains(String[] values, String target) {
+    for (String value : values) {
+      if (value.equals(target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String translateDirect(String javaKey, String value) {
+    if ("client.writer.bucket.no-key-assigner".equals(javaKey)) {
+      return value.trim().toLowerCase().replace('-', '_');
+    }
+    return value;
+  }
+
+  private static long parseMemoryBytes(String value) {
+    String normalized = value.trim().toLowerCase().replaceAll("\\s+", "");
+    long multiplier = 1;
+    String number = normalized;
+    if (normalized.endsWith("bytes")) {
+      number = normalized.substring(0, normalized.length() - "bytes".length());
+    } else if (normalized.endsWith("byte")) {
+      number = normalized.substring(0, normalized.length() - "byte".length());
+    } else if (normalized.endsWith("kib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L;
+    } else if (normalized.endsWith("kb") || normalized.endsWith("k")) {
+      number = normalized.replaceAll("k[b]?$", "");
+      multiplier = 1024L;
+    } else if (normalized.endsWith("mib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L * 1024L;
+    } else if (normalized.endsWith("mb") || normalized.endsWith("m")) {
+      number = normalized.replaceAll("m[b]?$", "");
+      multiplier = 1024L * 1024L;
+    } else if (normalized.endsWith("gib")) {
+      number = normalized.substring(0, normalized.length() - 3);
+      multiplier = 1024L * 1024L * 1024L;
+    } else if (normalized.endsWith("gb") || normalized.endsWith("g")) {
+      number = normalized.replaceAll("g[b]?$", "");
+      multiplier = 1024L * 1024L * 1024L;
+    } else if (normalized.endsWith("b")) {
+      number = normalized.substring(0, normalized.length() - 1);
+    }
+    return Long.parseLong(number) * multiplier;
+  }
+
+  private static long parseDurationMillis(String value) {
+    String trimmed = value.trim();
+    if (trimmed.toUpperCase().startsWith("P")) {
+      return Duration.parse(trimmed).toMillis();
+    }
+    String normalized = trimmed.toLowerCase().replaceAll("\\s+", "");
+    if (normalized.endsWith("ms")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 2));
+    }
+    if (normalized.endsWith("s")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 1000L;
+    }
+    if (normalized.endsWith("min")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 3)) * 60_000L;
+    }
+    if (normalized.endsWith("m")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 60_000L;
+    }
+    if (normalized.endsWith("h")) {
+      return Long.parseLong(normalized.substring(0, normalized.length() - 1)) * 3_600_000L;
+    }
+    return Long.parseLong(normalized);
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslator.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslator.java
@@ -1,0 +1,32 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import org.apache.fluss.flink.source.split.LogSplit;
+import org.apache.fluss.flink.source.split.SourceSplitBase;
+import org.apache.fluss.metadata.TableBucket;
+
+/** Converts Fluss's public source splits into the minimal native log-reader assignment. */
+public final class FlussSplitTranslator {
+
+  private FlussSplitTranslator() {}
+
+  public static boolean isNativeLogSplit(SourceSplitBase split) {
+    return split.isLogSplit();
+  }
+
+  public static NativeFlussLogSplit translateLogSplit(SourceSplitBase split) {
+    if (!split.isLogSplit()) {
+      throw new IllegalArgumentException(
+          "native Fluss proof path only accepts log splits, got " + split.getClass().getSimpleName());
+    }
+    LogSplit log = split.asLogSplit();
+    TableBucket bucket = log.getTableBucket();
+    return new NativeFlussLogSplit(
+        log.splitId(),
+        bucket.getTableId(),
+        bucket.getPartitionId(),
+        log.getPartitionName(),
+        bucket.getBucket(),
+        log.getStartingOffset(),
+        log.getStoppingOffset().orElse(null));
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussLogSplit.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussLogSplit.java
@@ -1,0 +1,60 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import java.util.OptionalLong;
+
+/** Concrete log-table split assignment passed from Flink's Fluss enumerator to the native reader. */
+public final class NativeFlussLogSplit {
+
+  private final String splitId;
+  private final long tableId;
+  private final Long partitionId;
+  private final String partitionName;
+  private final int bucket;
+  private final long startingOffset;
+  private final Long stoppingOffset;
+
+  NativeFlussLogSplit(
+      String splitId,
+      long tableId,
+      Long partitionId,
+      String partitionName,
+      int bucket,
+      long startingOffset,
+      Long stoppingOffset) {
+    this.splitId = splitId;
+    this.tableId = tableId;
+    this.partitionId = partitionId;
+    this.partitionName = partitionName;
+    this.bucket = bucket;
+    this.startingOffset = startingOffset;
+    this.stoppingOffset = stoppingOffset;
+  }
+
+  public String splitId() {
+    return splitId;
+  }
+
+  public long tableId() {
+    return tableId;
+  }
+
+  public OptionalLong partitionId() {
+    return partitionId == null ? OptionalLong.empty() : OptionalLong.of(partitionId);
+  }
+
+  public String partitionName() {
+    return partitionName;
+  }
+
+  public int bucket() {
+    return bucket;
+  }
+
+  public long startingOffset() {
+    return startingOffset;
+  }
+
+  public OptionalLong stoppingOffset() {
+    return stoppingOffset == null ? OptionalLong.empty() : OptionalLong.of(stoppingOffset);
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussRecord.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussRecord.java
@@ -1,0 +1,23 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import io.github.jordepic.streamfusion.operator.ArrowBatch;
+
+/** One Arrow batch from a Fluss log split plus the split offset after the batch. */
+final class NativeFlussRecord {
+
+  private final ArrowBatch batch;
+  private final long nextOffset;
+
+  NativeFlussRecord(ArrowBatch batch, long nextOffset) {
+    this.batch = batch;
+    this.nextOffset = nextOffset;
+  }
+
+  ArrowBatch batch() {
+    return batch;
+  }
+
+  long nextOffset() {
+    return nextOffset;
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussRecordEmitter.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussRecordEmitter.java
@@ -1,0 +1,18 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import io.github.jordepic.streamfusion.operator.ArrowBatch;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.fluss.flink.source.split.SourceSplitState;
+
+/** Emits native Fluss Arrow batches and advances the Fluss log split state. */
+final class NativeFlussRecordEmitter
+    implements RecordEmitter<NativeFlussRecord, ArrowBatch, SourceSplitState> {
+
+  @Override
+  public void emitRecord(
+      NativeFlussRecord record, SourceOutput<ArrowBatch> output, SourceSplitState splitState) {
+    output.collect(record.batch());
+    splitState.asLogSplitState().setNextOffset(record.nextOffset());
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSource.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSource.java
@@ -1,0 +1,159 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import io.github.jordepic.streamfusion.operator.ArrowBatch;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.fluss.client.initializer.OffsetsInitializer;
+import org.apache.fluss.flink.source.enumerator.FlinkSourceEnumerator;
+import org.apache.fluss.flink.source.reader.LeaseContext;
+import org.apache.fluss.flink.source.split.SourceSplitBase;
+import org.apache.fluss.flink.source.split.SourceSplitSerializer;
+import org.apache.fluss.flink.source.state.FlussSourceEnumeratorStateSerializer;
+import org.apache.fluss.flink.source.state.SourceEnumeratorState;
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.source.LakeSplit;
+import org.apache.fluss.metadata.TableBucket;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.predicate.Predicate;
+
+/**
+ * Native Fluss source for log tables. The JVM keeps Fluss' enumerator, split serializers, startup
+ * offsets, and checkpoint state; the task-side reader consumes assigned log splits with fluss-rs and
+ * emits Arrow batches directly.
+ */
+public final class NativeFlussSource
+    implements Source<ArrowBatch, SourceSplitBase, SourceEnumeratorState> {
+
+  private static final long serialVersionUID = 1L;
+  private static final long POLL_TIMEOUT_MILLIS = 100L;
+
+  private final org.apache.fluss.config.Configuration flussConfig;
+  private final TablePath tablePath;
+  private final boolean hasPrimaryKey;
+  private final boolean partitioned;
+  private final OffsetsInitializer offsetsInitializer;
+  private final long scanPartitionDiscoveryIntervalMs;
+  private final boolean streaming;
+  private final Predicate partitionFilters;
+  private final LakeSource<LakeSplit> lakeSource;
+  private final LeaseContext leaseContext;
+  private final String[] nativeConfigKeys;
+  private final String[] nativeConfigValues;
+  private final int[] projectedFields;
+
+  public NativeFlussSource(
+      org.apache.fluss.config.Configuration flussConfig,
+      TablePath tablePath,
+      boolean hasPrimaryKey,
+      boolean partitioned,
+      OffsetsInitializer offsetsInitializer,
+      long scanPartitionDiscoveryIntervalMs,
+      boolean streaming,
+      Predicate partitionFilters,
+      LakeSource<LakeSplit> lakeSource,
+      LeaseContext leaseContext,
+      String[] nativeConfigKeys,
+      String[] nativeConfigValues,
+      int[] projectedFields) {
+    this.flussConfig = flussConfig;
+    this.tablePath = tablePath;
+    this.hasPrimaryKey = hasPrimaryKey;
+    this.partitioned = partitioned;
+    this.offsetsInitializer = offsetsInitializer;
+    this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
+    this.streaming = streaming;
+    this.partitionFilters = partitionFilters;
+    this.lakeSource = lakeSource;
+    this.leaseContext = leaseContext;
+    this.nativeConfigKeys = nativeConfigKeys;
+    this.nativeConfigValues = nativeConfigValues;
+    this.projectedFields = projectedFields;
+  }
+
+  @Override
+  public Boundedness getBoundedness() {
+    return streaming ? Boundedness.CONTINUOUS_UNBOUNDED : Boundedness.BOUNDED;
+  }
+
+  @Override
+  public SourceReader<ArrowBatch, SourceSplitBase> createReader(SourceReaderContext context) {
+    Supplier<SplitReader<NativeFlussRecord, SourceSplitBase>> splitReaderSupplier =
+        () ->
+            new NativeFlussSplitReader(
+                nativeConfigKeys,
+                nativeConfigValues,
+                tablePath.getDatabaseName(),
+                tablePath.getTableName(),
+                projectedFields,
+                POLL_TIMEOUT_MILLIS);
+    return new NativeFlussSourceReader(
+        splitReaderSupplier, new NativeFlussRecordEmitter(), new Configuration(), context);
+  }
+
+  @Override
+  public SplitEnumerator<SourceSplitBase, SourceEnumeratorState> createEnumerator(
+      SplitEnumeratorContext<SourceSplitBase> enumContext) {
+    return new FlinkSourceEnumerator(
+        tablePath,
+        flussConfig,
+        hasPrimaryKey,
+        partitioned,
+        enumContext,
+        offsetsInitializer,
+        scanPartitionDiscoveryIntervalMs,
+        streaming,
+        partitionFilters,
+        lakeSource,
+        leaseContext,
+        false);
+  }
+
+  @Override
+  public SplitEnumerator<SourceSplitBase, SourceEnumeratorState> restoreEnumerator(
+      SplitEnumeratorContext<SourceSplitBase> enumContext, SourceEnumeratorState checkpoint)
+      throws IOException {
+    Set<TableBucket> assignedBuckets = checkpoint.getAssignedBuckets();
+    Map<Long, String> assignedPartitions = checkpoint.getAssignedPartitions();
+    List<SourceSplitBase> remainingSplits = checkpoint.getRemainingHybridLakeFlussSplits();
+    LeaseContext restoredLeaseContext =
+        new LeaseContext(checkpoint.getLeaseId(), leaseContext.getKvSnapshotLeaseDurationMs());
+    return new FlinkSourceEnumerator(
+        tablePath,
+        flussConfig,
+        hasPrimaryKey,
+        partitioned,
+        enumContext,
+        assignedBuckets,
+        assignedPartitions,
+        remainingSplits,
+        offsetsInitializer,
+        scanPartitionDiscoveryIntervalMs,
+        streaming,
+        partitionFilters,
+        lakeSource,
+        restoredLeaseContext,
+        true);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<SourceSplitBase> getSplitSerializer() {
+    return new SourceSplitSerializer(lakeSource);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<SourceEnumeratorState> getEnumeratorCheckpointSerializer() {
+    return new FlussSourceEnumeratorStateSerializer(lakeSource);
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSourceReader.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSourceReader.java
@@ -1,0 +1,46 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import io.github.jordepic.streamfusion.operator.ArrowBatch;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.fluss.flink.source.split.LogSplitState;
+import org.apache.fluss.flink.source.split.SourceSplitBase;
+import org.apache.fluss.flink.source.split.SourceSplitState;
+
+/** FLIP-27 source reader that swaps Fluss' row split reader for a native Arrow log reader. */
+final class NativeFlussSourceReader
+    extends SingleThreadMultiplexSourceReaderBase<
+        NativeFlussRecord, ArrowBatch, SourceSplitBase, SourceSplitState> {
+
+  NativeFlussSourceReader(
+      Supplier<SplitReader<NativeFlussRecord, SourceSplitBase>> splitReaderSupplier,
+      RecordEmitter<NativeFlussRecord, ArrowBatch, SourceSplitState> recordEmitter,
+      Configuration config,
+      SourceReaderContext context) {
+    super(splitReaderSupplier, recordEmitter, config, context);
+  }
+
+  @Override
+  protected void onSplitFinished(Map<String, SourceSplitState> finishedSplitIds) {
+    // Fluss' enumerator owns split completion bookkeeping.
+  }
+
+  @Override
+  protected SourceSplitState initializedState(SourceSplitBase split) {
+    if (!split.isLogSplit()) {
+      throw new IllegalArgumentException(
+          "native Fluss source supports log splits only, got " + split.getClass().getSimpleName());
+    }
+    return new LogSplitState(split.asLogSplit());
+  }
+
+  @Override
+  protected SourceSplitBase toSplitType(String splitId, SourceSplitState splitState) {
+    return splitState.toSourceSplit();
+  }
+}

--- a/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSplitReader.java
+++ b/src/main/java/io/github/jordepic/streamfusion/fluss/NativeFlussSplitReader.java
@@ -1,0 +1,170 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import io.github.jordepic.streamfusion.Native;
+import io.github.jordepic.streamfusion.operator.ArrowBatch;
+import io.github.jordepic.streamfusion.operator.NativeAllocator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.fluss.flink.source.split.SourceSplitBase;
+
+/**
+ * Native Fluss split reader for one Flink subtask. Fluss' enumerator assigns concrete log splits;
+ * this reader subscribes those buckets in fluss-rs and drains Arrow {@code RecordBatch}es directly.
+ */
+final class NativeFlussSplitReader implements SplitReader<NativeFlussRecord, SourceSplitBase> {
+
+  private static final long NO_PARTITION = Long.MIN_VALUE;
+  private static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
+
+  private final long handle;
+  private final long pollTimeoutMillis;
+  private final BufferAllocator allocator = NativeAllocator.SHARED;
+  private final Map<String, Long> stoppingOffsets = new HashMap<>();
+  private final Map<String, Long> positions = new HashMap<>();
+  private final Map<String, NativeFlussLogSplit> splitsById = new HashMap<>();
+  private final Set<String> finished = new HashSet<>();
+
+  NativeFlussSplitReader(
+      String[] configKeys,
+      String[] configValues,
+      String databaseName,
+      String tableName,
+      int[] projectedFields,
+      long pollTimeoutMillis) {
+    this.pollTimeoutMillis = pollTimeoutMillis;
+    this.handle =
+        Native.openFlussReader(configKeys, configValues, databaseName, tableName, projectedFields);
+  }
+
+  @Override
+  public RecordsWithSplitIds<NativeFlussRecord> fetch() {
+    int pending = Native.pollFlussBatch(handle, pollTimeoutMillis);
+    RecordsBySplits.Builder<NativeFlussRecord> builder = new RecordsBySplits.Builder<>();
+    for (int i = 0; i < pending; i++) {
+      try (ArrowArray outArray = ArrowArray.allocateNew(allocator);
+          ArrowSchema outSchema = ArrowSchema.allocateNew(allocator)) {
+        long[] meta = new long[1];
+        String[] splitId = new String[1];
+        Native.drainFlussSplit(
+            handle, meta, splitId, outArray.memoryAddress(), outSchema.memoryAddress());
+        VectorSchemaRoot root =
+            Data.importVectorSchemaRoot(allocator, outArray, outSchema, NativeAllocator.DICTIONARIES);
+        positions.put(splitId[0], meta[0]);
+        builder.add(splitId[0], new NativeFlussRecord(new ArrowBatch(root), meta[0]));
+      }
+    }
+
+    List<NativeFlussLogSplit> justFinished = new ArrayList<>();
+    for (Map.Entry<String, Long> stop : stoppingOffsets.entrySet()) {
+      String splitId = stop.getKey();
+      if (!finished.contains(splitId)
+          && positions.getOrDefault(splitId, Long.MIN_VALUE) >= stop.getValue()) {
+        builder.addFinishedSplit(splitId);
+        finished.add(splitId);
+        justFinished.add(splitsById.get(splitId));
+      }
+    }
+    if (!justFinished.isEmpty()) {
+      Native.unassignFlussSplits(
+          handle,
+          tableIds(justFinished),
+          partitionIds(justFinished),
+          buckets(justFinished));
+    }
+    return builder.build();
+  }
+
+  @Override
+  public void handleSplitsChanges(SplitsChange<SourceSplitBase> splitsChanges) {
+    List<SourceSplitBase> splits = splitsChanges.splits();
+    List<NativeFlussLogSplit> nativeSplits = new ArrayList<>(splits.size());
+    for (SourceSplitBase split : splits) {
+      NativeFlussLogSplit nativeSplit = FlussSplitTranslator.translateLogSplit(split);
+      nativeSplits.add(nativeSplit);
+      splitsById.put(nativeSplit.splitId(), nativeSplit);
+      positions.put(nativeSplit.splitId(), nativeSplit.startingOffset());
+      nativeSplit
+          .stoppingOffset()
+          .ifPresent(stop -> stoppingOffsets.put(nativeSplit.splitId(), stop));
+    }
+    Native.assignFlussSplits(
+        handle,
+        splitIds(nativeSplits),
+        tableIds(nativeSplits),
+        partitionIds(nativeSplits),
+        buckets(nativeSplits),
+        startingOffsets(nativeSplits),
+        stoppingOffsets(nativeSplits));
+  }
+
+  @Override
+  public void wakeUp() {
+    // Native poll uses a short bounded timeout; no interrupt is needed.
+  }
+
+  @Override
+  public void close() {
+    Native.closeFlussReader(handle);
+  }
+
+  private static String[] splitIds(List<NativeFlussLogSplit> splits) {
+    String[] values = new String[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).splitId();
+    }
+    return values;
+  }
+
+  private static long[] tableIds(List<NativeFlussLogSplit> splits) {
+    long[] values = new long[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).tableId();
+    }
+    return values;
+  }
+
+  private static long[] partitionIds(List<NativeFlussLogSplit> splits) {
+    long[] values = new long[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).partitionId().orElse(NO_PARTITION);
+    }
+    return values;
+  }
+
+  private static long[] buckets(List<NativeFlussLogSplit> splits) {
+    long[] values = new long[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).bucket();
+    }
+    return values;
+  }
+
+  private static long[] startingOffsets(List<NativeFlussLogSplit> splits) {
+    long[] values = new long[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).startingOffset();
+    }
+    return values;
+  }
+
+  private static long[] stoppingOffsets(List<NativeFlussLogSplit> splits) {
+    long[] values = new long[splits.size()];
+    for (int i = 0; i < splits.size(); i++) {
+      values[i] = splits.get(i).stoppingOffset().orElse(NO_STOPPING_OFFSET);
+    }
+    return values;
+  }
+}

--- a/src/test/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslatorTest.java
+++ b/src/test/java/io/github/jordepic/streamfusion/fluss/FlussConfigTranslatorTest.java
@@ -1,0 +1,94 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FlussConfigTranslatorTest {
+
+  private static Map<String, String> translated(Map<String, String> options) {
+    FlussConfigTranslator.Result result = FlussConfigTranslator.translate(options);
+    assertTrue(
+        result.isTranslated(), () -> "expected translation, got " + result.fallbackReason());
+    return result.config();
+  }
+
+  private static String fallback(Map<String, String> options) {
+    FlussConfigTranslator.Result result = FlussConfigTranslator.translate(options);
+    assertFalse(result.isTranslated(), "expected fallback, got translation");
+    return result.fallbackReason().orElseThrow();
+  }
+
+  @Test
+  void mapsScannerClientKnobsToRustConfigFields() {
+    Map<String, String> config =
+        translated(
+            Map.of(
+                "bootstrap.servers", "localhost:9123",
+                "client.scanner.log.max-poll-records", "2048",
+                "client.scanner.log.fetch.max-bytes", "16 mb",
+                "client.scanner.log.fetch.max-bytes-for-bucket", "1 mb",
+                "client.scanner.log.fetch.min-bytes", "1 bytes",
+                "client.scanner.log.fetch.wait-max-time", "PT0.5S",
+                "client.scanner.remote-log.prefetch-num", "8",
+                "client.remote-file.download-thread-num", "4"));
+
+    assertEquals("localhost:9123", config.get("bootstrap_servers"));
+    assertEquals("2048", config.get("scanner_log_max_poll_records"));
+    assertEquals("16777216", config.get("scanner_log_fetch_max_bytes"));
+    assertEquals("1048576", config.get("scanner_log_fetch_max_bytes_for_bucket"));
+    assertEquals("1", config.get("scanner_log_fetch_min_bytes"));
+    assertEquals("500", config.get("scanner_log_fetch_wait_max_time_ms"));
+    assertEquals("8", config.get("scanner_remote_log_prefetch_num"));
+    assertEquals("4", config.get("remote_file_download_thread_num"));
+  }
+
+  @Test
+  void keepsFlinkCoordinationOptionsOutOfNativeConfig() {
+    FlussConfigTranslator.Result result =
+        FlussConfigTranslator.translate(
+            Map.of(
+                "bootstrap.servers", "localhost:9123",
+                "scan.startup.mode", "earliest",
+                "scan.partition.discovery.interval", "1 min"));
+
+    assertTrue(result.isTranslated());
+    assertFalse(result.config().containsKey("scan.startup.mode"));
+    assertFalse(result.config().containsKey("scan.partition.discovery.interval"));
+    assertEquals("earliest", result.coordinationOptions().get("scan.startup.mode"));
+    assertEquals("1 min", result.coordinationOptions().get("scan.partition.discovery.interval"));
+  }
+
+  @Test
+  void mapsBasicPlainSaslButRejectsUnsupportedMechanism() {
+    Map<String, String> config =
+        translated(
+            Map.of(
+                "client.security.protocol", "sasl",
+                "client.security.sasl.mechanism", "PLAIN",
+                "client.security.sasl.username", "alice",
+                "client.security.sasl.password", "secret"));
+
+    assertEquals("sasl", config.get("security_protocol"));
+    assertEquals("PLAIN", config.get("security_sasl_mechanism"));
+    assertEquals("alice", config.get("security_sasl_username"));
+    assertEquals("secret", config.get("security_sasl_password"));
+    assertTrue(
+        fallback(
+                Map.of(
+                    "client.security.protocol", "sasl",
+                    "client.security.sasl.mechanism", "SCRAM-SHA-256"))
+            .contains("PLAIN"));
+  }
+
+  @Test
+  void fallsBackOnClientOptionsNotRepresentedInFlussRsConfig() {
+    assertTrue(fallback(Map.of("client.request-timeout", "30 s")).contains("request-timeout"));
+    assertTrue(fallback(Map.of("client.scanner.log.check-crc", "true")).contains("check-crc"));
+    assertTrue(fallback(Map.of("client.security.sasl.jaas.config", "x")).contains("jaas"));
+    assertTrue(fallback(Map.of("client.scanner.future-option", "true")).contains("unmapped"));
+  }
+}

--- a/src/test/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslatorTest.java
+++ b/src/test/java/io/github/jordepic/streamfusion/fluss/FlussSplitTranslatorTest.java
@@ -1,0 +1,51 @@
+package io.github.jordepic.streamfusion.fluss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.fluss.flink.source.split.HybridSnapshotLogSplit;
+import org.apache.fluss.flink.source.split.LogSplit;
+import org.apache.fluss.metadata.TableBucket;
+import org.junit.jupiter.api.Test;
+
+class FlussSplitTranslatorTest {
+
+  @Test
+  void extractsNativeAssignmentFromNonPartitionedLogSplit() {
+    LogSplit split = new LogSplit(new TableBucket(7L, 2), null, 11L, 42L);
+
+    NativeFlussLogSplit nativeSplit = FlussSplitTranslator.translateLogSplit(split);
+
+    assertEquals(split.splitId(), nativeSplit.splitId());
+    assertEquals(7L, nativeSplit.tableId());
+    assertFalse(nativeSplit.partitionId().isPresent());
+    assertEquals(2, nativeSplit.bucket());
+    assertEquals(11L, nativeSplit.startingOffset());
+    assertEquals(42L, nativeSplit.stoppingOffset().orElseThrow());
+  }
+
+  @Test
+  void extractsNativeAssignmentFromPartitionedLogSplit() {
+    LogSplit split = new LogSplit(new TableBucket(7L, 99L, 3), "dt=2026-07-04", 5L);
+
+    NativeFlussLogSplit nativeSplit = FlussSplitTranslator.translateLogSplit(split);
+
+    assertEquals(7L, nativeSplit.tableId());
+    assertEquals(99L, nativeSplit.partitionId().orElseThrow());
+    assertEquals("dt=2026-07-04", nativeSplit.partitionName());
+    assertEquals(3, nativeSplit.bucket());
+    assertEquals(5L, nativeSplit.startingOffset());
+    assertFalse(nativeSplit.stoppingOffset().isPresent());
+  }
+
+  @Test
+  void rejectsHybridSnapshotLogSplitForTheLogTableProofPath() {
+    HybridSnapshotLogSplit split =
+        new HybridSnapshotLogSplit(new TableBucket(7L, 2), null, 123L, 4L);
+
+    assertFalse(FlussSplitTranslator.isNativeLogSplit(split));
+    assertThrows(IllegalArgumentException.class, () -> FlussSplitTranslator.translateLogSplit(split));
+  }
+}


### PR DESCRIPTION
## Summary
- add the Java FLIP-27 source shell that keeps Fluss split enumeration on the JVM
- add the task-side split reader shape that will drain native Arrow batches once the Rust reader lands
- declare the Fluss JNI boundary in `Native`
- add a native `flussFeatureBuilt` probe stub that returns false until the real fluss-rs reader is linked

## Stack
- Stacked on #4. Until #4 merges, this PR diff includes the config/split seam from #4 as well. After #4 lands, this branch should be rebased onto main so the diff collapses to this source-shell slice.

## Scope
- no planner substitution yet
- no fluss-rs dependency yet
- no Cargo.lock changes
- no Arrow version changes

## Tests
- `MAVEN_DIR=/tmp/apache-maven-3.9.10 JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH="/tmp/fake-cargo:$MAVEN_DIR/bin:$PATH" mvn -B -ntp -Dnative.profile=release -Dtest=FlussConfigTranslatorTest,FlussSplitTranslatorTest test`
- `rustfmt --check native/src/fluss.rs`
- `cargo check --manifest-path native/Cargo.toml`
- `cargo check --manifest-path native/Cargo.toml --no-default-features --features fluss`
- `cargo test --manifest-path native/Cargo.toml --lib flussFeatureBuilt`

Note: full `cargo fmt --check` reports formatting drift in existing native files unrelated to this PR, so I only checked the new Rust file.