### PR TITLE
Correct FLOAT precision and column-less batch routing

### DIFF
--- a/native/src/exchange.rs
+++ b/native/src/exchange.rs
@@ -35,7 +35,13 @@ pub(crate) fn partition_batch(
             .collect();
         out.push((
             key_group,
-            RecordBatch::try_new(batch.schema(), columns).expect("sub batch"),
+            // A key-only projection carries no columns, and Arrow cannot infer a row count from none.
+            RecordBatch::try_new_with_options(
+                batch.schema(),
+                columns,
+                &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(indices.len())),
+            )
+            .expect("sub batch"),
         ));
     }
     out
@@ -74,7 +80,13 @@ pub(crate) fn partition_batch_by_key_group(
             Some((
                 key_group,
                 ordinals,
-                RecordBatch::try_new(batch.schema(), columns).expect("key-group sub-batch"),
+                RecordBatch::try_new_with_options(
+                    batch.schema(),
+                    columns,
+                    &arrow::record_batch::RecordBatchOptions::new()
+                        .with_row_count(Some(indices.len())),
+                )
+                .expect("key-group sub-batch"),
             ))
         })
         .collect()
@@ -244,4 +256,35 @@ pub extern "system" fn Java_tech_streamfusion_Native_concatBatches<'local>(
         let merged = concat_batches(&batches[0].schema(), &batches).expect("concat batches");
         export_record_batch(merged, out_array_address, out_schema_address);
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::Schema;
+    use std::sync::Arc;
+
+    fn zero_column_batch(rows: usize) -> RecordBatch {
+        RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(rows)),
+        )
+        .expect("zero-column batch")
+    }
+
+    /// A projection can leave no columns behind, and Arrow refuses to infer a row count from none.
+    #[test]
+    fn partitions_a_zero_column_batch() {
+        let batch = zero_column_batch(4);
+        let parts = partition_batch(&batch, &[], &[], 128, 2);
+        assert_eq!(parts.iter().map(|(_, b)| b.num_rows()).sum::<usize>(), 4);
+    }
+
+    #[test]
+    fn partitions_a_zero_column_batch_by_key_group() {
+        let batch = zero_column_batch(3);
+        let parts = partition_batch_by_key_group(&batch, &[], &[], 128);
+        assert_eq!(parts.iter().map(|(_, _, b)| b.num_rows()).sum::<usize>(), 3);
+    }
 }

--- a/native/src/expr.rs
+++ b/native/src/expr.rs
@@ -33,6 +33,8 @@ pub(crate) fn build_expr(
         7 => logical_lit(longs[arg] as i32),
         8 => logical_lit(longs[arg] as i16),
         9 => logical_lit(longs[arg] as i8),
+        // Likewise for FLOAT, which the host evaluates in single precision.
+        22 => logical_lit(doubles[arg] as f32),
         11 => {
             // A widening numeric cast: build the single child, then wrap it. `arg` is the target code.
             let child = build_expr(

--- a/src/main/java/tech/streamfusion/planner/RexExpression.java
+++ b/src/main/java/tech/streamfusion/planner/RexExpression.java
@@ -88,6 +88,9 @@ final class RexExpression {
   private static final int KIND_DECIMAL_DIVIDE = 20;
   private static final int KIND_DECIMAL_MOD = 21;
 
+  // A single-precision literal, so a FLOAT expression is not widened to double by its constants.
+  private static final int KIND_LIT_FLOAT = 22;
+
   // Cast target type codes, mirrored on the native side.
   private static final int CAST_TINYINT = 0;
   private static final int CAST_SMALLINT = 1;
@@ -406,6 +409,17 @@ final class RexExpression {
         }
       case FLOAT:
       case REAL:
+        {
+          Double value = literal.getValueAs(Double.class);
+          if (value == null) {
+            return false;
+          }
+          // The host evaluates FLOAT arithmetic in single precision. A double literal would widen the
+          // whole expression, changing both the result type the plan promised and its last bits.
+          add(KIND_LIT_FLOAT, doubles.size(), 0);
+          doubles.add(value);
+          return true;
+        }
       case DOUBLE:
         {
           Double value = literal.getValueAs(Double.class);

--- a/src/test/java/tech/streamfusion/FlinkCalcSqlHarnessTest.java
+++ b/src/test/java/tech/streamfusion/FlinkCalcSqlHarnessTest.java
@@ -29,6 +29,25 @@ class FlinkCalcSqlHarnessTest {
   }
 
   @Test
+  void floatLiteralArithmeticMatchesHost() throws Exception {
+    // A double-typed constant would widen the whole expression, so the projection would come back
+    // as DOUBLE where the plan promised FLOAT.
+    NativeParity.assertParity(
+        FlinkCalcSqlHarnessTest::environment, "SELECT f4 * CAST(2 AS FLOAT) FROM f");
+  }
+
+  @Test
+  void floatColumnArithmeticMatchesHost() throws Exception {
+    NativeParity.assertParity(FlinkCalcSqlHarnessTest::environment, "SELECT f4 + f4, f4 - f4 FROM f");
+  }
+
+  @Test
+  void floatCastProjectionMatchesHost() throws Exception {
+    NativeParity.assertParity(
+        FlinkCalcSqlHarnessTest::environment, "SELECT CAST(v AS FLOAT) * f4 FROM f");
+  }
+
+  @Test
   void mixedComputedAndColumnProjectionMatchesHost() throws Exception {
     NativeParity.assertParity(FlinkCalcSqlHarnessTest::environment, "SELECT v + k, s, k FROM f");
   }
@@ -474,11 +493,16 @@ class FlinkCalcSqlHarnessTest {
     StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
     DataStream<Row> source =
         env.fromData(
-            Types.ROW_NAMED(new String[] {"k", "v", "s"}, Types.LONG, Types.INT, Types.STRING),
-            Row.of(1L, 10, "a"),
-            Row.of(2L, 30, "b"),
-            Row.of(3L, 20, "c"),
-            Row.of(4L, 40, "d"));
+            Types.ROW_NAMED(
+                new String[] {"k", "v", "s", "f4"},
+                Types.LONG,
+                Types.INT,
+                Types.STRING,
+                Types.FLOAT),
+            Row.of(1L, 10, "a", 1.5f),
+            Row.of(2L, 30, "b", 2.25f),
+            Row.of(3L, 20, "c", 3.75f),
+            Row.of(4L, 40, "d", 4.125f));
     tEnv.createTemporaryView(
         "f",
         source,
@@ -486,6 +510,7 @@ class FlinkCalcSqlHarnessTest {
             .column("k", DataTypes.BIGINT())
             .column("v", DataTypes.INT())
             .column("s", DataTypes.STRING())
+            .column("f4", DataTypes.FLOAT())
             .build());
     return tEnv;
   }


### PR DESCRIPTION
## Summary:

Found two native-execution defects found while validating Flink 2.1.3 support (future PR). 

Both reproduce on `main` against Flink 2.2.1.

A projected FLOAT expression containing a FLOAT constant aborts the job. Such constants were encoded as double literals, so DataFusion promoted the whole expression to double precision and returned a DOUBLE column where the plan declared FLOAT. The columnar boundary selects a Flink column vector from the Arrow type it is handed rather than the type the plan declared, so the widened result arrived as a Double vector and threw `ClassCastException` the moment a FLOAT field was
read.

The scope is narrower than it first appears, which is why it went unnoticed: `f4 * CAST(2 AS FLOAT)` fails, but `f4 * 2` does not (narrow integer literals already carry their declared width), nor does `f4 + f4` (no literal to widen), nor a FLOAT literal confined to a filter predicate (the widening lands on the boolean mask, not a projected output column).

The width was wrong as well as the type. Flink evaluates FLOAT arithmetic in single precision, so computing in double and narrowing afterwards can differ in the last bits even where the cast succeeds.

The second is a task abort in the columnar exchange. Splitting a batch into per-channel sub-batches takes row subsets and rebuilds a batch from the resulting columns. A projection can legitimately leave no columns behind (a key-only shuffle carries routing information and nothing else), and Arrow cannot infer how many rows such a batch holds, so the split panicked.

Closes #28 

## Changes:
- Encodes single-precision constants as FLOAT literals rather than double, so a FLOAT expression keeps both its declared result type and the host's evaluation width.
- States the row count explicitly when building exchange sub-batches, covering both the destination and key-group splits, matching how the aggregate and calc paths already construct batches.
- Adds FLOAT coverage to the Calc parity tests, which had none.

## Testing
Validated locally with Java 17 (as always pls validate my parking here):

- Calc SQL parity: `mvn -pl :streamfusion-runtime test -Dtest=FlinkCalcSqlHarnessTest` 68 tests passing, including three new FLOAT cases (literal arithmetic, column
  arithmetic, and a cast projection).
- Native unit tests: `cd native && cargo test --lib exchange::` two new cases covering zero-column destination and key-group splits.
- Reproduced on clean `main` (`c9f7905c`) and confirmed fixed: a datagen table with a FLOAT column fails with `ArrowDoubleColumnVector cannot be cast to FloatColumnVector` before the change and returns correct values after. Verified across seven FLOAT query shapes; the three using a FLOAT literal in a projection fail before and pass after, the other four are unaffected either way.
- Upstream Flink suite, `CastFunctionITCase`:
  - Flink 2.2.1 — 557 tests, 0 failures, 0 errors.