### PR TITLE
Fail the upstream suite when the engine was never installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,24 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  suite-harness-tests:
+    name: Upstream suite harness tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Package suite agent
+        run: mvn -B -ntp -f dev/flink-suite/agent/pom.xml clean package
+      - name: Verify fork failures reach the launcher
+        run: python -m unittest discover -s dev/flink-suite -p 'test_fork_exit.py'
+
   native-tests:
     name: Rust tests
     runs-on: ubuntu-24.04

--- a/bin/flink-suite.sh
+++ b/bin/flink-suite.sh
@@ -23,7 +23,7 @@ readonly UNSHADED_BRIDGE_POM="${SUITE_ROOT}/flink-table-calcite-bridge-${FLINK_V
 readonly UNSHADED_SQL_PARSER_JAR="${SUITE_ROOT}/flink-sql-parser-${FLINK_VERSION}-unshaded.jar"
 readonly UNSHADED_SQL_PARSER_POM="${SUITE_ROOT}/flink-sql-parser-${FLINK_VERSION}-effective.pom"
 readonly SUITE_MODE="${1:-runtime}"
-readonly FLINK_MODULE_CONFIG="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED -Djunit.platform.reflection.search.useLegacySemantics=true -javaagent:${AGENT_JAR}"
+FLINK_MODULE_CONFIG="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED -Djunit.platform.reflection.search.useLegacySemantics=true -javaagent:${AGENT_JAR}"
 readonly FORMAT_MODULES="flink-formats/flink-json,flink-formats/flink-csv,flink-formats/flink-avro,flink-formats/flink-avro-confluent-registry,flink-formats/flink-protobuf"
 readonly PARQUET_MODULE="flink-formats/flink-parquet"
 readonly PARQUET_SINK_TESTS="org.apache.flink.formats.parquet.ParquetFsStreamingSinkITCase,org.apache.flink.formats.parquet.ParquetTimestampITCase"
@@ -230,6 +230,10 @@ if [[ "${SUITE_MODE}" == "formats" ]]; then
 else
   find "${REPORT_ROOT}" -mindepth 1 -maxdepth 1 -type f -delete
 fi
+AUDIT_ROOT="$(mktemp -d "${SUITE_ROOT}/audit-${SUITE_MODE}.XXXXXX")" || exit $?
+readonly AUDIT_ROOT
+FLINK_MODULE_CONFIG+=" \"-Dstreamfusion.flink-suite.audit-dir=${AUDIT_ROOT}\""
+
 MAVEN_TEST_ARGS=(
   -B -ntp -s "${MAVEN_SETTINGS}" \
   -Dmaven.repo.local="${SUITE_MAVEN_REPO}" \
@@ -237,6 +241,7 @@ MAVEN_TEST_ARGS=(
   -Dmaven.test.additionalClasspath="${STREAMFUSION_CLASSPATH}" \
   -Dstreamfusion.logFallbackReasons=true \
   -Dstreamfusion.native.development=true \
+  -Dmaven.test.failure.ignore=true \
   -Dfast \
   -Djunit.jupiter.execution.parallel.enabled=false \
   -Dflink.forkCountUnitTest="${FLINK_SUITE_UNIT_FORKS:-2}" \
@@ -292,14 +297,11 @@ if [[ "${SUITE_MODE}" == "parquet" && ${TEST_STATUS} -eq 0 ]]; then
   fi
 fi
 
-SUMMARY_ARGS=("${REPORT_ROOT}")
+SUMMARY_ARGS=("${REPORT_ROOT}" --test-exit-code "${TEST_STATUS}" --audit-dir "${AUDIT_ROOT}")
 if [[ "${SUITE_MODE}" == "runtime" || "${SUITE_MODE}" == "diagnostic" ]]; then
   SUMMARY_ARGS+=(--xfail "org.apache.flink.table.planner.runtime.batch.sql.CalcITCase#testCurrentDate")
 fi
 python3 "${REPO_ROOT}/dev/flink-suite/summarize.py" "${SUMMARY_ARGS[@]}"
 readonly SUMMARY_STATUS=$?
 
-if [[ ${TEST_STATUS} -ne 0 && ${SUMMARY_STATUS} -ne 0 ]]; then
-  exit "${TEST_STATUS}"
-fi
 exit "${SUMMARY_STATUS}"

--- a/dev/flink-suite/agent/pom.xml
+++ b/dev/flink-suite/agent/pom.xml
@@ -26,6 +26,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.1</version>
                 <executions>

--- a/dev/flink-suite/agent/src/main/java/tech/streamfusion/suite/StreamFusionSuiteAgent.java
+++ b/dev/flink-suite/agent/src/main/java/tech/streamfusion/suite/StreamFusionSuiteAgent.java
@@ -2,12 +2,18 @@ package tech.streamfusion.suite;
 
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -32,6 +38,9 @@ public final class StreamFusionSuiteAgent {
   private static final AtomicBoolean NATIVE_MEMORY_STATE_REPORTED = new AtomicBoolean();
   private static final AtomicBoolean ROCKSDB_STATE_REPORTED = new AtomicBoolean();
   private static final AtomicBoolean NATIVE_PARQUET_WRITER_REPORTED = new AtomicBoolean();
+  private static final Set<String> TRANSFORMED_TYPES = Collections.synchronizedSet(new HashSet<>());
+  private static final AtomicBoolean PLANNER_ADVICE_ENTERED = new AtomicBoolean();
+  private static volatile Instrumentation INSTRUMENTATION;
   private static final Set<Object> INSTALLED_CONFIGS =
       Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
   private static final ThreadLocal<Boolean> UNMODIFIED_PLAN_SETUP = new ThreadLocal<>();
@@ -41,8 +50,13 @@ public final class StreamFusionSuiteAgent {
   private StreamFusionSuiteAgent() {}
 
   public static void premain(String arguments, Instrumentation instrumentation) {
+    INSTRUMENTATION = instrumentation;
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(StreamFusionSuiteAgent::auditInterception, "streamfusion-suite-audit"));
     new AgentBuilder.Default()
         .with(AgentBuilder.Listener.StreamWriting.toSystemError().withTransformationsOnly())
+        .with(new InterceptionAudit())
         .type(named(PLANNER_FACTORY))
         .transform(
             (builder, type, classLoader, module, protectionDomain) ->
@@ -124,6 +138,7 @@ public final class StreamFusionSuiteAgent {
 
     @Advice.OnMethodEnter
     static void enter(@Advice.Argument(0) Object context) {
+      StreamFusionSuiteAgent.recordPlannerAdviceEntered();
       try {
         if (requiresUnmodifiedFlinkPlan()) {
           return;
@@ -275,6 +290,74 @@ public final class StreamFusionSuiteAgent {
         System.err.println(
             "StreamFusion upstream Parquet suite created native Parquet sink writer");
       }
+    }
+  }
+
+  public static void recordPlannerAdviceEntered() {
+    PLANNER_ADVICE_ENTERED.set(true);
+  }
+
+  /**
+   * Fails the JVM when the planner interception never took effect.
+   *
+   * <p>The advice is attached by class and method name, so on an untested Flink version a rename or
+   * a signature change attaches nothing at all and the upstream suite then passes while running
+   * stock Flink — a green result that proves nothing. Loaded-but-never-instrumented is unambiguous
+   * and halts; instrumented-but-never-entered only warns, because a suite can load the factory
+   * without ever building a table environment.
+   */
+  static void auditInterception() {
+    Instrumentation instrumentation = INSTRUMENTATION;
+    if (instrumentation == null) {
+      return;
+    }
+    boolean plannerLoaded = isLoaded(instrumentation, PLANNER_FACTORY);
+    boolean delegateLoaded = isLoaded(instrumentation, DELEGATE_PLANNER_FACTORY);
+    if (!plannerLoaded && !delegateLoaded) {
+      return; // no table stack in this JVM, so no interception was expected
+    }
+    List<String> problems = new ArrayList<>();
+    if (plannerLoaded && !TRANSFORMED_TYPES.contains(PLANNER_FACTORY)) {
+      problems.add(PLANNER_FACTORY + " was loaded but never instrumented");
+    }
+    if (delegateLoaded && !TRANSFORMED_TYPES.contains(DELEGATE_PLANNER_FACTORY)) {
+      problems.add(DELEGATE_PLANNER_FACTORY + " was loaded but never instrumented");
+    }
+    if (!problems.isEmpty()) {
+      System.err.println(
+          "FATAL: the StreamFusion suite agent did not instrument the Flink planner factory."
+              + " This run exercised stock Flink and any pass it reported is meaningless.");
+      problems.forEach(problem -> System.err.println("  - " + problem));
+      System.err.flush();
+      Runtime.getRuntime().halt(70);
+    }
+    if (!PLANNER_ADVICE_ENTERED.get()) {
+      System.err.println(
+          "WARNING: the StreamFusion suite agent instrumented the Flink planner factory, but its"
+              + " create(..) advice never ran — check that the method matcher still applies.");
+    }
+  }
+
+  private static boolean isLoaded(Instrumentation instrumentation, String className) {
+    for (Class<?> loaded : instrumentation.getAllLoadedClasses()) {
+      if (className.equals(loaded.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Records which interception targets actually took effect. */
+  private static final class InterceptionAudit extends AgentBuilder.Listener.Adapter {
+
+    @Override
+    public void onTransformation(
+        TypeDescription typeDescription,
+        ClassLoader classLoader,
+        JavaModule module,
+        boolean loaded,
+        DynamicType dynamicType) {
+      TRANSFORMED_TYPES.add(typeDescription.getName());
     }
   }
 }

--- a/dev/flink-suite/agent/src/main/java/tech/streamfusion/suite/StreamFusionSuiteAgent.java
+++ b/dev/flink-suite/agent/src/main/java/tech/streamfusion/suite/StreamFusionSuiteAgent.java
@@ -1,22 +1,28 @@
 package tech.streamfusion.suite;
 
 import java.lang.instrument.Instrumentation;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.utility.JavaModule;
-
+import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import net.bytebuddy.utility.JavaModule;
 
 /** Installs StreamFusion when an untouched upstream Flink test creates a streaming planner. */
 public final class StreamFusionSuiteAgent {
@@ -25,6 +31,8 @@ public final class StreamFusionSuiteAgent {
       "org.apache.flink.table.planner.delegation.DefaultPlannerFactory";
   private static final String DELEGATE_PLANNER_FACTORY =
       "org.apache.flink.table.planner.loader.DelegatePlannerFactory";
+  private static final String PLANNER_CONTEXT = "org.apache.flink.table.delegation.PlannerFactory$Context";
+  private static final String TABLE_ENVIRONMENT = "org.apache.flink.table.api.internal.TableEnvironmentImpl";
   private static final String JSON_PLAN_TEST_BASE =
       "org.apache.flink.table.planner.utils.JsonPlanTestBase";
   private static final String STREAM_EXECUTION_ENVIRONMENT =
@@ -38,11 +46,15 @@ public final class StreamFusionSuiteAgent {
   private static final AtomicBoolean NATIVE_MEMORY_STATE_REPORTED = new AtomicBoolean();
   private static final AtomicBoolean ROCKSDB_STATE_REPORTED = new AtomicBoolean();
   private static final AtomicBoolean NATIVE_PARQUET_WRITER_REPORTED = new AtomicBoolean();
-  private static final Set<String> TRANSFORMED_TYPES = Collections.synchronizedSet(new HashSet<>());
-  private static final AtomicBoolean PLANNER_ADVICE_ENTERED = new AtomicBoolean();
-  private static volatile Instrumentation INSTRUMENTATION;
-  private static final Set<Object> INSTALLED_CONFIGS =
+  private static final Map<ClassLoader, Set<String>> TRANSFORMED_TYPES =
+      Collections.synchronizedMap(new WeakHashMap<>());
+  private static final ConcurrentLinkedQueue<String> AUDIT_FAILURES = new ConcurrentLinkedQueue<>();
+  private static final Set<Object> CONFIRMED_CONFIGS =
       Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+  private static Path pendingAudit;
+  private static final Object AUDIT_LOCK = new Object();
+  private static boolean auditFinalized;
+  private static volatile Instrumentation INSTRUMENTATION;
   private static final ThreadLocal<Boolean> UNMODIFIED_PLAN_SETUP = new ThreadLocal<>();
   private static final String JSON_PLAN_TEST_PACKAGE =
       "org.apache.flink.table.planner.runtime.stream.jsonplan.";
@@ -51,24 +63,38 @@ public final class StreamFusionSuiteAgent {
 
   public static void premain(String arguments, Instrumentation instrumentation) {
     INSTRUMENTATION = instrumentation;
+    String auditDirectory = System.getProperty("streamfusion.flink-suite.audit-dir");
+    if (auditDirectory != null) {
+      try {
+        Path directory = Path.of(auditDirectory);
+        Files.createDirectories(directory);
+        pendingAudit = directory.resolve(ProcessHandle.current().pid() + "-" + UUID.randomUUID() + ".pending");
+        Files.createFile(pendingAudit);
+      } catch (Exception failure) {
+        throw new IllegalStateException("cannot start StreamFusion suite audit", failure);
+      }
+    }
+
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(StreamFusionSuiteAgent::auditInterception, "streamfusion-suite-audit"));
     new AgentBuilder.Default()
         .with(AgentBuilder.Listener.StreamWriting.toSystemError().withTransformationsOnly())
         .with(new InterceptionAudit())
-        .type(named(PLANNER_FACTORY))
+        .type(named(PLANNER_FACTORY).or(named(DELEGATE_PLANNER_FACTORY)))
+        .transform(
+            (builder, type, classLoader, module, protectionDomain) -> {
+              var create = named("create").and(takesArguments(1))
+                  .and(takesArgument(0, named(PLANNER_CONTEXT))).and(not(isAbstract()));
+              if (type.getDeclaredMethods().filter(create).isEmpty()) {
+                throw new IllegalStateException("planner factory has no declared create(Context): " + type.getName());
+              }
+              return builder.visit(Advice.to(InstallStreamFusion.class).on(create));
+            })
+        .type(named(TABLE_ENVIRONMENT))
         .transform(
             (builder, type, classLoader, module, protectionDomain) ->
-                builder.visit(
-                    Advice.to(InstallStreamFusion.class)
-                        .on(named("create").and(takesArguments(1)))))
-        .type(named(DELEGATE_PLANNER_FACTORY))
-        .transform(
-            (builder, type, classLoader, module, protectionDomain) ->
-                builder.visit(
-                    Advice.to(InstallStreamFusion.class)
-                        .on(named("create").and(takesArguments(1)))))
+                builder.visit(Advice.to(VerifyInstallation.class).on(isConstructor())))
         .type(named(JSON_PLAN_TEST_BASE))
         .transform(
             (builder, type, classLoader, module, protectionDomain) ->
@@ -116,14 +142,6 @@ public final class StreamFusionSuiteAgent {
     return NATIVE_PARQUET_WRITER_REPORTED.compareAndSet(false, true);
   }
 
-  public static boolean markConfigForInstallation(Object tableConfig) {
-    return INSTALLED_CONFIGS.add(tableConfig);
-  }
-
-  public static void unmarkConfigForInstallation(Object tableConfig) {
-    INSTALLED_CONFIGS.remove(tableConfig);
-  }
-
   public static void enterUnmodifiedPlanSetup() {
     UNMODIFIED_PLAN_SETUP.set(Boolean.TRUE);
   }
@@ -138,55 +156,7 @@ public final class StreamFusionSuiteAgent {
 
     @Advice.OnMethodEnter
     static void enter(@Advice.Argument(0) Object context) {
-      StreamFusionSuiteAgent.recordPlannerAdviceEntered();
-      try {
-        if (requiresUnmodifiedFlinkPlan()) {
-          return;
-        }
-        Object tableConfig =
-            Class.forName("org.apache.flink.table.delegation.PlannerFactory$Context")
-                .getMethod("getTableConfig")
-                .invoke(context);
-        Object runtimeMode =
-            tableConfig
-                .getClass()
-                .getMethod("get", Class.forName("org.apache.flink.configuration.ConfigOption"))
-                .invoke(
-                    tableConfig,
-                    Class.forName("org.apache.flink.configuration.ExecutionOptions")
-                        .getField("RUNTIME_MODE")
-                        .get(null));
-        if (!"STREAMING".equals(runtimeMode.toString())) {
-          return;
-        }
-        if (!StreamFusionSuiteAgent.markConfigForInstallation(tableConfig)) {
-          return;
-        }
-
-        try {
-          ClassLoader classLoader = context.getClass().getClassLoader();
-          Class<?> nativePlanner =
-              Class.forName("tech.streamfusion.planner.NativePlanner", true, classLoader);
-          nativePlanner
-              .getMethod("install", Class.forName("org.apache.flink.table.api.TableConfig"))
-              .invoke(null, tableConfig);
-        } catch (ClassNotFoundException
-            | NoSuchMethodException
-            | IllegalAccessException
-            | InvocationTargetException e) {
-          StreamFusionSuiteAgent.unmarkConfigForInstallation(tableConfig);
-          throw e;
-        }
-        if (StreamFusionSuiteAgent.reportActivation()) {
-          System.err.println("StreamFusion enabled for upstream Flink streaming planner tests");
-        }
-      } catch (ClassNotFoundException
-          | NoSuchMethodException
-          | NoSuchFieldException
-          | IllegalAccessException
-          | InvocationTargetException e) {
-        throw new IllegalStateException("StreamFusion planner installation failed", e);
-      }
+      StreamFusionSuiteAgent.install(context);
     }
 
     public static boolean requiresUnmodifiedFlinkPlan() {
@@ -293,71 +263,150 @@ public final class StreamFusionSuiteAgent {
     }
   }
 
-  public static void recordPlannerAdviceEntered() {
-    PLANNER_ADVICE_ENTERED.set(true);
-  }
-
-  /**
-   * Fails the JVM when the planner interception never took effect.
-   *
-   * <p>The advice is attached by class and method name, so on an untested Flink version a rename or
-   * a signature change attaches nothing at all and the upstream suite then passes while running
-   * stock Flink — a green result that proves nothing. Loaded-but-never-instrumented is unambiguous
-   * and halts; instrumented-but-never-entered only warns, because a suite can load the factory
-   * without ever building a table environment.
-   */
-  static void auditInterception() {
-    Instrumentation instrumentation = INSTRUMENTATION;
-    if (instrumentation == null) {
+  public static void install(Object context) {
+    if (InstallStreamFusion.requiresUnmodifiedFlinkPlan()) {
       return;
     }
-    boolean plannerLoaded = isLoaded(instrumentation, PLANNER_FACTORY);
-    boolean delegateLoaded = isLoaded(instrumentation, DELEGATE_PLANNER_FACTORY);
-    if (!plannerLoaded && !delegateLoaded) {
-      return; // no table stack in this JVM, so no interception was expected
-    }
-    List<String> problems = new ArrayList<>();
-    if (plannerLoaded && !TRANSFORMED_TYPES.contains(PLANNER_FACTORY)) {
-      problems.add(PLANNER_FACTORY + " was loaded but never instrumented");
-    }
-    if (delegateLoaded && !TRANSFORMED_TYPES.contains(DELEGATE_PLANNER_FACTORY)) {
-      problems.add(DELEGATE_PLANNER_FACTORY + " was loaded but never instrumented");
-    }
-    if (!problems.isEmpty()) {
-      System.err.println(
-          "FATAL: the StreamFusion suite agent did not instrument the Flink planner factory."
-              + " This run exercised stock Flink and any pass it reported is meaningless.");
-      problems.forEach(problem -> System.err.println("  - " + problem));
-      System.err.flush();
-      Runtime.getRuntime().halt(70);
-    }
-    if (!PLANNER_ADVICE_ENTERED.get()) {
-      System.err.println(
-          "WARNING: the StreamFusion suite agent instrumented the Flink planner factory, but its"
-              + " create(..) advice never ran — check that the method matcher still applies.");
+    try {
+      ClassLoader loader = context.getClass().getClassLoader();
+      Object tableConfig = Class.forName(PLANNER_CONTEXT, true, loader)
+          .getMethod("getTableConfig").invoke(context);
+      if (!isStreaming(tableConfig)) {
+        return;
+      }
+      synchronized (CONFIRMED_CONFIGS) {
+        if (CONFIRMED_CONFIGS.contains(tableConfig)) {
+          return;
+        }
+        Class<?> nativePlanner = Class.forName("tech.streamfusion.planner.NativePlanner", true, loader);
+        nativePlanner.getMethod("install", Class.forName("org.apache.flink.table.api.TableConfig", true, loader))
+            .invoke(null, tableConfig);
+        CONFIRMED_CONFIGS.add(tableConfig);
+      }
+      if (reportActivation()) {
+        System.err.println("StreamFusion enabled for upstream Flink streaming planner tests");
+      }
+    } catch (ReflectiveOperationException | RuntimeException | LinkageError failure) {
+      recordFailure("streaming planner installation failed: " + describe(failure));
+      throw new IllegalStateException("StreamFusion planner installation failed", failure);
     }
   }
 
-  private static boolean isLoaded(Instrumentation instrumentation, String className) {
-    for (Class<?> loaded : instrumentation.getAllLoadedClasses()) {
-      if (className.equals(loaded.getName())) {
-        return true;
+  private static boolean isStreaming(Object config) throws ReflectiveOperationException {
+    ClassLoader loader = config.getClass().getClassLoader();
+    Object mode = config.getClass()
+        .getMethod("get", Class.forName("org.apache.flink.configuration.ConfigOption", true, loader))
+        .invoke(config, Class.forName("org.apache.flink.configuration.ExecutionOptions", true, loader)
+            .getField("RUNTIME_MODE").get(null));
+    return "STREAMING".equals(mode.toString());
+  }
+
+  public static final class VerifyInstallation {
+    @Advice.OnMethodExit
+    static void exit(@Advice.FieldValue("tableConfig") Object config) {
+      StreamFusionSuiteAgent.verifyInstallation(config);
+    }
+  }
+
+  public static void verifyInstallation(Object config) {
+    if (InstallStreamFusion.requiresUnmodifiedFlinkPlan()) {
+      return;
+    }
+    try {
+      if (isStreaming(config) && !CONFIRMED_CONFIGS.contains(config)) {
+        recordFailure("streaming table environment completed without successful StreamFusion installation");
+      }
+    } catch (ReflectiveOperationException | RuntimeException | LinkageError failure) {
+      recordFailure("could not verify streaming planner installation: " + describe(failure));
+    }
+  }
+
+  static void auditInterception() {
+    try {
+      for (Class<?> type : INSTRUMENTATION.getAllLoadedClasses()) {
+        String name = type.getName();
+        if (name.equals(PLANNER_FACTORY) || name.equals(DELEGATE_PLANNER_FACTORY)
+            || name.equals(TABLE_ENVIRONMENT)) {
+          synchronized (TRANSFORMED_TYPES) {
+            if (!TRANSFORMED_TYPES.getOrDefault(type.getClassLoader(), Set.of()).contains(name)) {
+              recordFailure(name + " was loaded but never instrumented in loader " + type.getClassLoader());
+            }
+          }
+        }
+      }
+    } catch (Exception | LinkageError failure) {
+      recordFailure("StreamFusion audit could not complete: " + failure);
+    }
+    synchronized (AUDIT_LOCK) {
+      publishReceipt(!AUDIT_FAILURES.isEmpty());
+      auditFinalized = true;
+      if (!AUDIT_FAILURES.isEmpty()) {
+        haltAudit();
       }
     }
-    return false;
   }
 
-  /** Records which interception targets actually took effect. */
+  private static String describe(Throwable failure) {
+    StringBuilder message = new StringBuilder();
+    Set<Throwable> seen = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+    while (failure != null && seen.add(failure)) {
+      if (message.length() > 0) {
+        message.append(" caused by ");
+      }
+      message.append(failure);
+      failure = failure.getCause();
+    }
+    return message.toString();
+  }
+
+  private static void recordFailure(String message) {
+    synchronized (AUDIT_LOCK) {
+      AUDIT_FAILURES.add(message);
+      // A later shutdown hook must not leave a successful receipt behind after discovering failure.
+      if (auditFinalized) {
+        publishReceipt(true);
+        haltAudit();
+      }
+    }
+  }
+
+  private static void publishReceipt(boolean failed) {
+    if (pendingAudit == null) {
+      return;
+    }
+    try {
+      String name = pendingAudit.getFileName().toString();
+      Path completed = pendingAudit.resolveSibling(
+          name.substring(0, name.lastIndexOf('.')) + (failed ? ".failed" : ".ok"));
+      if (!completed.equals(pendingAudit)) {
+        Files.move(pendingAudit, completed);
+        pendingAudit = completed;
+      }
+    } catch (Exception failure) {
+      AUDIT_FAILURES.add("could not publish StreamFusion audit result: " + describe(failure));
+    }
+  }
+
+  private static void haltAudit() {
+    System.err.println("FATAL: StreamFusion suite installation audit failed.");
+    AUDIT_FAILURES.forEach(problem -> System.err.println("  - " + problem));
+    System.err.flush();
+    Runtime.getRuntime().halt(70);
+  }
+
   private static final class InterceptionAudit extends AgentBuilder.Listener.Adapter {
+    @Override
+    public void onTransformation(TypeDescription type, ClassLoader loader, JavaModule module,
+        boolean loaded, DynamicType dynamicType) {
+      synchronized (TRANSFORMED_TYPES) {
+        TRANSFORMED_TYPES.computeIfAbsent(loader, ignored -> new HashSet<>()).add(type.getName());
+      }
+    }
 
     @Override
-    public void onTransformation(
-        TypeDescription typeDescription,
-        ClassLoader classLoader,
-        JavaModule module,
-        boolean loaded,
-        DynamicType dynamicType) {
-      TRANSFORMED_TYPES.add(typeDescription.getName());
+    public void onError(String type, ClassLoader loader, JavaModule module, boolean loaded,
+        Throwable failure) {
+      recordFailure("instrumentation failed for " + type + " in loader " + loader + ": " + describe(failure));
     }
   }
 }

--- a/dev/flink-suite/summarize.py
+++ b/dev/flink-suite/summarize.py
@@ -13,7 +13,23 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("reports", type=pathlib.Path)
     parser.add_argument("--xfail", action="append", default=[])
+    parser.add_argument("--test-exit-code", type=int, default=0)
+    parser.add_argument("--audit-dir", type=pathlib.Path)
     args = parser.parse_args()
+
+    infrastructure: list[str] = []
+    if args.test_exit_code:
+        infrastructure.append(f"test process exited with status {args.test_exit_code}")
+    for dump in sorted(args.reports.rglob("*.dump*")):
+        infrastructure.append(f"Surefire infrastructure diagnostic: {dump}")
+    if args.audit_dir is not None:
+        receipts = sorted(args.audit_dir.iterdir()) if args.audit_dir.is_dir() else []
+        if not receipts:
+            infrastructure.append("no StreamFusion agent audit receipts were produced")
+        for receipt in receipts:
+            if not receipt.is_file() or receipt.suffix != ".ok":
+                infrastructure.append(f"incomplete or failed StreamFusion agent audit: {receipt.name}")
+
 
     files = sorted(args.reports.rglob("TEST-*.xml"))
     if not files:
@@ -96,7 +112,14 @@ def main() -> int:
             if detail:
                 print(f"  - {detail}")
 
-    return 1 if unexpected_failures or unexpected_errors or malformed else 0
+    if infrastructure:
+        print()
+        print("## Infrastructure failures")
+        for problem in infrastructure:
+            print(f"- {problem}")
+
+    return 1 if unexpected_failures or unexpected_errors or malformed or infrastructure else 0
+
 
 
 if __name__ == "__main__":

--- a/dev/flink-suite/test_fork_exit.py
+++ b/dev/flink-suite/test_fork_exit.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Real launcher/Maven/Surefire TCP-fork exit regressions (JDK 17+, Maven).
+
+Package the standalone suite agent before running this file in CI.
+These tests never build the agent or check out Flink. Only the upstream checkout
+and its mvnw entry point are fixtures: Maven, Surefire 3.2.2, JUnit, the shaded
+agent, reports, receipts and exit statuses are real. Released Maven dependencies
+share the normal local cache; only projects and test outputs are disposable.
+Network access is needed for uncached dependencies.
+All process output, XML, dumps and receipts are printed before fixture cleanup,
+even on failure. A late halt must fail the launcher, not merely the JVM audit.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "bin/flink-suite.sh"
+AGENT = REPO_ROOT / "dev/flink-suite/agent/target/streamfusion-flink-suite-agent-1.0-SNAPSHOT.jar"
+SETTINGS = REPO_ROOT / "dev/flink-suite/settings.xml"
+MAVEN_TIMEOUT_SECONDS = 300
+
+POM = """<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>tech.streamfusion.fixture</groupId>
+  <artifactId>real-fork-exit</artifactId>
+  <version>1.0</version>
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.2</version>
+        <configuration>
+          <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <testFailureIgnore>true</testFailureIgnore>
+          <failIfNoTests>true</failIfNoTests>
+          <forkedProcessTimeoutInSeconds>90</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>60</forkedProcessExitTimeoutInSeconds>
+          <reportsDirectory>${fixture.reports}</reportsDirectory>
+          <argLine>${surefire.module.config}</argLine>
+          <systemPropertyVariables>
+            <fixture.reports>${fixture.reports}</fixture.reports>
+            <fixture.marker>${fixture.marker}</fixture.marker>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+# This shim accepts exactly the launcher's cleanliness query, never real Git.
+GIT_SHIM = """#!/bin/sh
+if [ "$#" -eq 4 ] && [ "$1" = "-C" ] && [ "$2" = "$REAL_FORK_FLINK" ] && [ "$3" = "status" ] && [ "$4" = "--short" ]; then
+  printf 'checked clean fixture checkout\\n' > "$REAL_FORK_ROOT/git.log"
+  exit 0
+fi
+printf 'Unexpected Git operation blocked\\n' >&2
+exit 97
+"""
+
+# Translate only the absent upstream reactor/goal to a minimal real project.
+# No generated reports/receipts, inferred exit codes, or Maven-output rewriting.
+MVNW_SHIM = """#!/bin/bash
+set -u
+printf '%s\\n' "$@" > "$REAL_FORK_ROOT/launcher-args.log"
+properties=()
+for argument in "$@"; do
+  case "$argument" in
+        -Dmaven.repo.local=*) ;;  # Reuse Maven's dependency cache, not the disposable Flink cache.
+    -D*) properties+=("$argument") ;;
+  esac
+done
+printf '%s\\n' "$REAL_FORK_MVN" > "$REAL_FORK_ROOT/maven-command.log"
+printf '%s\\n' -B -ntp -s "$REAL_FORK_SETTINGS" -f "$REAL_FORK_PROJECT/pom.xml" "${properties[@]}" "-Dfixture.reports=$REAL_FORK_REPORTS" "-Dfixture.marker=$REAL_FORK_ROOT/fork.marker" test >> "$REAL_FORK_ROOT/maven-command.log"
+"$REAL_FORK_MVN" -B -ntp -s "$REAL_FORK_SETTINGS" -f "$REAL_FORK_PROJECT/pom.xml" "${properties[@]}" "-Dfixture.reports=$REAL_FORK_REPORTS" "-Dfixture.marker=$REAL_FORK_ROOT/fork.marker" test
+maven_exit=$?
+printf '%s\\n' "$maven_exit" > "$REAL_FORK_ROOT/maven.exit"
+printf 'REAL_MAVEN_EXIT=%s\\n' "$maven_exit"
+exit "$maven_exit"
+"""
+
+
+class ForkExitTest(unittest.TestCase):
+    def test_late_halt_after_ok_and_passing_xml_fails_launcher(self):
+        maven = shutil.which("mvn")
+        self.assertIsNotNone(maven, "Prerequisite missing: real Maven on PATH")
+        self.assertIsNotNone(shutil.which("java"), "Prerequisite missing: Java 17+")
+        self.assertIsNotNone(shutil.which("javac"), "Prerequisite missing: JDK 17+")
+        self.assertTrue(AGENT.is_file(), "Prerequisite missing: package the shaded suite agent first")
+        with tempfile.TemporaryDirectory(prefix="sf-real-fork-late-") as temporary:
+            root = Path(temporary).resolve()
+            suite = root / "suite with spaces"
+            flink = suite / "flink-2.2.1"
+            (flink / ".git").mkdir(parents=True)
+            (suite / "streamfusion-classpath.txt").write_text("", encoding="utf-8")
+            (suite / "flink-table-planner-2.2.1-unshaded.jar").touch()
+            reports = flink / "flink-table/flink-table-planner/target/surefire-reports"
+            project = root / "project"
+            sources = project / "src/test/java"
+            sources.mkdir(parents=True)
+            (project / "pom.xml").write_text(POM, encoding="utf-8")
+            (sources / "RealForkExitTest.java").write_text("""import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.TimeUnit;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RealForkExitTest {
+    @Test
+    void passesBeforeLateHalt() throws Exception {
+        Path audit = Path.of(System.getProperty("streamfusion.flink-suite.audit-dir"));
+        Path reports = Path.of(System.getProperty("fixture.reports"));
+        Path marker = Path.of(System.getProperty("fixture.marker"));
+        Path pending;
+        try (var entries = Files.list(audit)) {
+            pending = entries.filter(path -> path.toString().endsWith(".pending"))
+                    .findFirst().orElseThrow();
+        }
+        Path ok = pending.resolveSibling(pending.getFileName().toString().replace(".pending", ".ok"));
+        Path report = reports.resolve("TEST-RealForkExitTest.xml");
+        WatchService watcher = audit.getFileSystem().newWatchService();
+        audit.register(watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+        reports.register(watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            // Surefire's Java streams may already be closed after its TCP bye.
+            PrintStream rawError = new PrintStream(new FileOutputStream(FileDescriptor.err), true, StandardCharsets.UTF_8);
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            try (watcher) {
+                while (true) {
+                    // Register before shutdown, then check existing files before polling:
+                    // neither receipt-before-registration nor receipt-before-poll is lost.
+                    if (Files.isRegularFile(ok) && Files.isRegularFile(report)) {
+                        try {
+                            var xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report.toFile());
+                            var result = xml.getDocumentElement();
+                            if (!"1".equals(result.getAttribute("tests"))
+                                    || !"0".equals(result.getAttribute("failures"))
+                                    || !"0".equals(result.getAttribute("errors"))
+                                    || !"0".equals(result.getAttribute("skipped"))
+                                    || result.getElementsByTagName("testcase").getLength() != 1
+                                    || result.getElementsByTagName("failure").getLength() != 0
+                                    || result.getElementsByTagName("error").getLength() != 0) {
+                                throw new IllegalStateException("JUnit report was not one passing test");
+                            }
+                            String evidence = "REAL_FORK_LATE_HALT_70_AFTER_OK_AND_PASSING_XML\\n"
+                                    + "ok=" + ok + "\\npassingXml=" + report + "\\n";
+                            Files.writeString(marker, evidence);
+                            rawError.print(evidence);
+                            rawError.flush();
+                            Runtime.getRuntime().halt(70);
+                        } catch (org.xml.sax.SAXException | java.io.IOException incompleteReport) {
+                            // A create/modify event may precede the XML writer's close.
+                        }
+                    }
+                    long remaining = deadline - System.nanoTime();
+                    if (remaining <= 0) {
+                        throw new IllegalStateException("Timed out waiting for .ok and passing XML");
+                    }
+                    WatchKey key = watcher.poll(remaining, TimeUnit.NANOSECONDS);
+                    if (key == null) {
+                        throw new IllegalStateException("Timed out waiting for audit/report notification");
+                    }
+                    key.pollEvents();
+                    if (!key.reset()) {
+                        throw new IllegalStateException("Audit/report watch became invalid");
+                    }
+                }
+            } catch (Throwable failure) {
+                rawError.println("REAL_FORK_FIXTURE_ERROR");
+                failure.printStackTrace(rawError);
+                rawError.flush();
+                Runtime.getRuntime().halt(71);
+            }
+        }, "real-fork-late-halt"));
+        assertEquals(2, 1 + 1);
+    }
+}
+""", encoding="utf-8")
+            shim_bin = root / "shim-bin"
+            shim_bin.mkdir()
+            (shim_bin / "git").write_text(GIT_SHIM, encoding="utf-8")
+            (shim_bin / "git").chmod(0o755)
+            (shim_bin / "python3").symlink_to(sys.executable)
+            (flink / "mvnw").write_text(MVNW_SHIM, encoding="utf-8")
+            (flink / "mvnw").chmod(0o755)
+            env = os.environ.copy()
+            env.update({
+                "PATH": str(shim_bin) + os.pathsep + os.environ.get("PATH", os.defpath),
+                "FLINK_SUITE_ROOT": str(suite), "FLINK_SUITE_REUSE_BUILD": "true",
+                "FLINK_VERSION": "2.2.1", "FLINK_SUITE_TEST": "RealForkExitTest",
+                "FLINK_SUITE_UNIT_FORKS": "1", "FLINK_SUITE_IT_FORKS": "1",
+                "REAL_FORK_ROOT": str(root), "REAL_FORK_FLINK": str(flink),
+                "REAL_FORK_PROJECT": str(project), "REAL_FORK_REPORTS": str(reports),
+                "REAL_FORK_MVN": maven, "REAL_FORK_SETTINGS": str(SETTINGS),
+                "PYTHONDONTWRITEBYTECODE": "1",
+            })
+            env.pop("BASH_ENV", None)
+            env.pop("ENV", None)
+            env.pop("JAVA_TOOL_OPTIONS", None)
+            env.pop("JDK_JAVA_OPTIONS", None)
+            env.pop("_JAVA_OPTIONS", None)
+            env.pop("MAVEN_OPTS", None)
+            env.pop("MAVEN_ARGS", None)
+            env.pop("MAVEN_PROJECTBASEDIR", None)
+            timed_out = False
+
+            with (root / "launcher.log").open("w", encoding="utf-8") as output:
+                process = subprocess.Popen(
+                    ["/bin/bash", str(RUNNER), "runtime"], cwd=root, env=env,
+                    stdout=output, stderr=subprocess.STDOUT, start_new_session=True,
+                )
+                try:
+                    process.wait(timeout=MAVEN_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                finally:
+                    # Kill only this fixture's session, including any orphaned fork.
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait(timeout=10)
+                    output.flush()
+                    print(f"\n=== {self.id()} outer_exit={process.returncode} timeout={timed_out} ===", flush=True)
+                    print((root / "launcher.log").read_text(encoding="utf-8", errors="replace"), flush=True)
+                    # Diagnostic enumeration only; each behavioral assertion is inline below.
+                    for artifact in sorted(reports.glob("*")) + sorted(suite.glob("audit-*/*")) + sorted(root.glob("*.marker")) + sorted(root.glob("maven.*")) + sorted(root.glob("*-args.log")):
+                        if artifact.is_file():
+                            print(f"--- {artifact.relative_to(root)} ---\n{artifact.read_text(encoding='utf-8', errors='replace')}", flush=True)
+
+            log = (root / "launcher.log").read_text(encoding="utf-8", errors="replace")
+            self.assertFalse(timed_out, "Real Maven/launcher exceeded the timeout; see captured diagnostics")
+            self.assertTrue((root / "maven.exit").is_file(), log)
+            maven_exit = int((root / "maven.exit").read_text(encoding="utf-8"))
+            self.assertIn(f"REAL_MAVEN_EXIT={maven_exit}", log)
+            self.assertRegex(log, r"(?:maven-surefire-plugin|surefire):3\.2\.2:test")
+            self.assertNotIn("REAL_FORK_FIXTURE_ERROR", log)
+            self.assertIn("REAL_FORK_LATE_HALT_70_AFTER_OK_AND_PASSING_XML", log)
+            self.assertTrue((root / "fork.marker").is_file(), log)
+            self.assertIn("REAL_FORK_LATE_HALT_70_AFTER_OK_AND_PASSING_XML", (root / "fork.marker").read_text(encoding="utf-8"))
+            audits = list(suite.glob("audit-runtime.*"))
+            self.assertEqual(len(audits), 1, log)
+            receipts = list(audits[0].iterdir())
+            self.assertEqual(len(receipts), 1, log)
+            self.assertTrue(receipts[0].is_file(), log)
+            self.assertEqual(receipts[0].suffix, ".ok", log)
+            self.assertIn(f"ok={receipts[0]}", (root / "fork.marker").read_text(encoding="utf-8"))
+            self.assertEqual(len(list(reports.glob("TEST-*.xml"))), 1, log)
+            report = reports / "TEST-RealForkExitTest.xml"
+            self.assertIn(f"passingXml={report}", (root / "fork.marker").read_text(encoding="utf-8"))
+            xml = ET.parse(report).getroot()
+            self.assertEqual(xml.get("tests"), "1")
+            self.assertEqual(xml.get("failures"), "0")
+            self.assertEqual(xml.get("errors"), "0")
+            self.assertEqual(xml.get("skipped"), "0")
+            self.assertEqual(len(xml.findall("testcase")), 1)
+            self.assertEqual(xml.find("testcase").get("name"), "passesBeforeLateHalt")
+            self.assertIsNone(xml.find("testcase/failure"))
+            self.assertIsNone(xml.find("testcase/error"))
+            self.assertEqual((root / "git.log").read_text(encoding="utf-8"), "checked clean fixture checkout\n")
+            self.assertIn("-Dmaven.test.failure.ignore=true", (root / "launcher-args.log").read_text(encoding="utf-8").splitlines())
+            self.assertNotEqual(
+                process.returncode, 0,
+                f"FALSE GREEN: real fork halted 70 after .ok and passing XML; Maven returned {maven_exit}, launcher returned 0.\n{log}",
+            )
+
+    def test_halt_before_audit_leaves_pending_and_fails_launcher(self):
+        maven = shutil.which("mvn")
+        self.assertIsNotNone(maven, "Prerequisite missing: real Maven on PATH")
+        self.assertIsNotNone(shutil.which("java"), "Prerequisite missing: Java 17+")
+        self.assertIsNotNone(shutil.which("javac"), "Prerequisite missing: JDK 17+")
+        self.assertTrue(AGENT.is_file(), "Prerequisite missing: package the shaded suite agent first")
+        with tempfile.TemporaryDirectory(prefix="sf-real-fork-early-") as temporary:
+            root = Path(temporary).resolve()
+            suite = root / "suite with spaces"
+            flink = suite / "flink-2.2.1"
+            (flink / ".git").mkdir(parents=True)
+            (suite / "streamfusion-classpath.txt").write_text("", encoding="utf-8")
+            (suite / "flink-table-planner-2.2.1-unshaded.jar").touch()
+            reports = flink / "flink-table/flink-table-planner/target/surefire-reports"
+            project = root / "project"
+            sources = project / "src/test/java"
+            sources.mkdir(parents=True)
+            (project / "pom.xml").write_text(POM, encoding="utf-8")
+            (sources / "RealForkExitTest.java").write_text("""import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RealForkExitTest {
+    @Test
+    void haltsBeforeAudit() throws Exception {
+        assertEquals(2, 1 + 1);
+        String marker = "REAL_FORK_EARLY_HALT_70_BEFORE_AUDIT";
+        Files.writeString(Path.of(System.getProperty("fixture.marker")), marker);
+        PrintStream rawError = new PrintStream(new FileOutputStream(FileDescriptor.err), true, StandardCharsets.UTF_8);
+        rawError.println(marker);
+        rawError.flush();
+        Runtime.getRuntime().halt(70);
+    }
+}
+""", encoding="utf-8")
+            shim_bin = root / "shim-bin"
+            shim_bin.mkdir()
+            (shim_bin / "git").write_text(GIT_SHIM, encoding="utf-8")
+            (shim_bin / "git").chmod(0o755)
+            (shim_bin / "python3").symlink_to(sys.executable)
+            (flink / "mvnw").write_text(MVNW_SHIM, encoding="utf-8")
+            (flink / "mvnw").chmod(0o755)
+            env = os.environ.copy()
+            env.update({
+                "PATH": str(shim_bin) + os.pathsep + os.environ.get("PATH", os.defpath),
+                "FLINK_SUITE_ROOT": str(suite), "FLINK_SUITE_REUSE_BUILD": "true",
+                "FLINK_VERSION": "2.2.1", "FLINK_SUITE_TEST": "RealForkExitTest",
+                "FLINK_SUITE_UNIT_FORKS": "1", "FLINK_SUITE_IT_FORKS": "1",
+                "REAL_FORK_ROOT": str(root), "REAL_FORK_FLINK": str(flink),
+                "REAL_FORK_PROJECT": str(project), "REAL_FORK_REPORTS": str(reports),
+                "REAL_FORK_MVN": maven, "REAL_FORK_SETTINGS": str(SETTINGS),
+                "PYTHONDONTWRITEBYTECODE": "1",
+            })
+            env.pop("BASH_ENV", None)
+            env.pop("ENV", None)
+            env.pop("JAVA_TOOL_OPTIONS", None)
+            env.pop("JDK_JAVA_OPTIONS", None)
+            env.pop("_JAVA_OPTIONS", None)
+            env.pop("MAVEN_OPTS", None)
+            env.pop("MAVEN_ARGS", None)
+            env.pop("MAVEN_PROJECTBASEDIR", None)
+            timed_out = False
+
+            with (root / "launcher.log").open("w", encoding="utf-8") as output:
+                process = subprocess.Popen(
+                    ["/bin/bash", str(RUNNER), "runtime"], cwd=root, env=env,
+                    stdout=output, stderr=subprocess.STDOUT, start_new_session=True,
+                )
+                try:
+                    process.wait(timeout=MAVEN_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                finally:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait(timeout=10)
+                    output.flush()
+                    print(f"\n=== {self.id()} outer_exit={process.returncode} timeout={timed_out} ===", flush=True)
+                    print((root / "launcher.log").read_text(encoding="utf-8", errors="replace"), flush=True)
+                    for artifact in sorted(reports.glob("*")) + sorted(suite.glob("audit-*/*")) + sorted(root.glob("*.marker")) + sorted(root.glob("maven.*")) + sorted(root.glob("*-args.log")):
+                        if artifact.is_file():
+                            print(f"--- {artifact.relative_to(root)} ---\n{artifact.read_text(encoding='utf-8', errors='replace')}", flush=True)
+
+            log = (root / "launcher.log").read_text(encoding="utf-8", errors="replace")
+            self.assertFalse(timed_out, "Real Maven/launcher exceeded the timeout; see captured diagnostics")
+            self.assertTrue((root / "maven.exit").is_file(), log)
+            maven_exit = int((root / "maven.exit").read_text(encoding="utf-8"))
+            self.assertIn(f"REAL_MAVEN_EXIT={maven_exit}", log)
+            self.assertRegex(log, r"(?:maven-surefire-plugin|surefire):3\.2\.2:test")
+            self.assertIn("REAL_FORK_EARLY_HALT_70_BEFORE_AUDIT", log)
+            self.assertEqual((root / "fork.marker").read_text(encoding="utf-8"), "REAL_FORK_EARLY_HALT_70_BEFORE_AUDIT")
+            self.assertIn("Process Exit Code: 70", log)
+            audits = list(suite.glob("audit-runtime.*"))
+            self.assertEqual(len(audits), 1, log)
+            receipts = list(audits[0].iterdir())
+            self.assertEqual(len(receipts), 1, log)
+            self.assertTrue(receipts[0].is_file(), log)
+            self.assertEqual(receipts[0].suffix, ".pending", log)
+            self.assertEqual(list(audits[0].glob("*.ok")), [])
+            self.assertEqual(list(reports.glob("TEST-*.xml")), [], log)
+            self.assertEqual((root / "git.log").read_text(encoding="utf-8"), "checked clean fixture checkout\n")
+            self.assertIn("-Dmaven.test.failure.ignore=true", (root / "launcher-args.log").read_text(encoding="utf-8").splitlines())
+            self.assertNotEqual(process.returncode, 0, f"FALSE GREEN: real fork halted before audit; Maven returned {maven_exit}.\n{log}")
+
+    def test_expected_junit_failure_has_ok_audit_and_zero_launcher_exit(self):
+        maven = shutil.which("mvn")
+        self.assertIsNotNone(maven, "Prerequisite missing: real Maven on PATH")
+        self.assertIsNotNone(shutil.which("java"), "Prerequisite missing: Java 17+")
+        self.assertIsNotNone(shutil.which("javac"), "Prerequisite missing: JDK 17+")
+        self.assertTrue(AGENT.is_file(), "Prerequisite missing: package the shaded suite agent first")
+        with tempfile.TemporaryDirectory(prefix="sf-real-fork-xfail-") as temporary:
+            root = Path(temporary).resolve()
+            suite = root / "suite with spaces"
+            flink = suite / "flink-2.2.1"
+            (flink / ".git").mkdir(parents=True)
+            (suite / "streamfusion-classpath.txt").write_text("", encoding="utf-8")
+            (suite / "flink-table-planner-2.2.1-unshaded.jar").touch()
+            reports = flink / "flink-table/flink-table-planner/target/surefire-reports"
+            project = root / "project"
+            sources = project / "src/test/java/org/apache/flink/table/planner/runtime/batch/sql"
+            sources.mkdir(parents=True)
+            (project / "pom.xml").write_text(POM, encoding="utf-8")
+            (sources / "CalcITCase.java").write_text("""package org.apache.flink.table.planner.runtime.batch.sql;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalcITCase {
+    @Test
+    void testCurrentDate() throws Exception {
+        String marker = "REAL_FORK_EXPECTED_JUNIT_ASSERTION_EXECUTED";
+        Files.writeString(Path.of(System.getProperty("fixture.marker")), marker);
+        System.out.println(marker);
+        assertEquals("expected date", "different date", marker);
+    }
+}
+""", encoding="utf-8")
+            shim_bin = root / "shim-bin"
+            shim_bin.mkdir()
+            (shim_bin / "git").write_text(GIT_SHIM, encoding="utf-8")
+            (shim_bin / "git").chmod(0o755)
+            (shim_bin / "python3").symlink_to(sys.executable)
+            (flink / "mvnw").write_text(MVNW_SHIM, encoding="utf-8")
+            (flink / "mvnw").chmod(0o755)
+            env = os.environ.copy()
+            env.update({
+                "PATH": str(shim_bin) + os.pathsep + os.environ.get("PATH", os.defpath),
+                "FLINK_SUITE_ROOT": str(suite), "FLINK_SUITE_REUSE_BUILD": "true",
+                "FLINK_VERSION": "2.2.1", "FLINK_SUITE_TEST": "org.apache.flink.table.planner.runtime.batch.sql.CalcITCase",
+                "FLINK_SUITE_UNIT_FORKS": "1", "FLINK_SUITE_IT_FORKS": "1",
+                "REAL_FORK_ROOT": str(root), "REAL_FORK_FLINK": str(flink),
+                "REAL_FORK_PROJECT": str(project), "REAL_FORK_REPORTS": str(reports),
+                "REAL_FORK_MVN": maven, "REAL_FORK_SETTINGS": str(SETTINGS),
+                "PYTHONDONTWRITEBYTECODE": "1",
+            })
+            env.pop("BASH_ENV", None)
+            env.pop("ENV", None)
+            env.pop("JAVA_TOOL_OPTIONS", None)
+            env.pop("JDK_JAVA_OPTIONS", None)
+            env.pop("_JAVA_OPTIONS", None)
+            env.pop("MAVEN_OPTS", None)
+            env.pop("MAVEN_ARGS", None)
+            env.pop("MAVEN_PROJECTBASEDIR", None)
+            timed_out = False
+
+            with (root / "launcher.log").open("w", encoding="utf-8") as output:
+                process = subprocess.Popen(
+                    ["/bin/bash", str(RUNNER), "runtime"], cwd=root, env=env,
+                    stdout=output, stderr=subprocess.STDOUT, start_new_session=True,
+                )
+                try:
+                    process.wait(timeout=MAVEN_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                finally:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait(timeout=10)
+                    output.flush()
+                    print(f"\n=== {self.id()} outer_exit={process.returncode} timeout={timed_out} ===", flush=True)
+                    print((root / "launcher.log").read_text(encoding="utf-8", errors="replace"), flush=True)
+                    for artifact in sorted(reports.glob("*")) + sorted(suite.glob("audit-*/*")) + sorted(root.glob("*.marker")) + sorted(root.glob("maven.*")) + sorted(root.glob("*-args.log")):
+                        if artifact.is_file():
+                            print(f"--- {artifact.relative_to(root)} ---\n{artifact.read_text(encoding='utf-8', errors='replace')}", flush=True)
+
+            log = (root / "launcher.log").read_text(encoding="utf-8", errors="replace")
+            self.assertFalse(timed_out, "Real Maven/launcher exceeded the timeout; see captured diagnostics")
+            self.assertTrue((root / "maven.exit").is_file(), log)
+            maven_exit = int((root / "maven.exit").read_text(encoding="utf-8"))
+            self.assertEqual(maven_exit, 0, log)
+            self.assertIn("REAL_MAVEN_EXIT=0", log)
+            self.assertRegex(log, r"(?:maven-surefire-plugin|surefire):3\.2\.2:test")
+            self.assertIn("REAL_FORK_EXPECTED_JUNIT_ASSERTION_EXECUTED", log)
+            self.assertEqual((root / "fork.marker").read_text(encoding="utf-8"), "REAL_FORK_EXPECTED_JUNIT_ASSERTION_EXECUTED")
+            audits = list(suite.glob("audit-runtime.*"))
+            self.assertEqual(len(audits), 1, log)
+            receipts = list(audits[0].iterdir())
+            self.assertEqual(len(receipts), 1, log)
+            self.assertTrue(receipts[0].is_file(), log)
+            self.assertEqual(receipts[0].suffix, ".ok", log)
+            self.assertEqual(len(list(reports.glob("TEST-*.xml"))), 1, log)
+            xml = ET.parse(reports / "TEST-org.apache.flink.table.planner.runtime.batch.sql.CalcITCase.xml").getroot()
+            self.assertEqual(xml.get("tests"), "1")
+            self.assertEqual(xml.get("failures"), "1")
+            self.assertEqual(xml.get("errors"), "0")
+            self.assertEqual(xml.get("skipped"), "0")
+            self.assertEqual(len(xml.findall("testcase")), 1)
+            case = xml.find("testcase")
+            self.assertEqual(case.get("classname"), "org.apache.flink.table.planner.runtime.batch.sql.CalcITCase")
+            self.assertEqual(case.get("name"), "testCurrentDate")
+            self.assertIsNone(case.find("skipped"))
+            self.assertIsNone(case.find("error"))
+            failure = case.find("failure")
+            self.assertIsNotNone(failure)
+            self.assertEqual(failure.get("type"), "org.opentest4j.AssertionFailedError")
+            self.assertIn("REAL_FORK_EXPECTED_JUNIT_ASSERTION_EXECUTED", failure.get("message", ""))
+            self.assertEqual((root / "git.log").read_text(encoding="utf-8"), "checked clean fixture checkout\n")
+            self.assertIn("-Dmaven.test.failure.ignore=true", (root / "launcher-args.log").read_text(encoding="utf-8").splitlines())
+            self.assertIn("- Expected upstream failures: 1", log)
+            self.assertIn("- Failures: 0", log)
+            self.assertIn("- Errors: 0", log)
+            self.assertIn("- Skipped: 0", log)
+            self.assertIn("org.apache.flink.table.planner.runtime.batch.sql.CalcITCase#testCurrentDate", log)
+            self.assertNotIn("## Infrastructure failures", log)
+            self.assertEqual(process.returncode, 0, log)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/upstream-flink-suite.md
+++ b/docs/upstream-flink-suite.md
@@ -53,6 +53,45 @@ Flink's plan unit tests assert stock physical operator names, so an accelerator 
 their golden output. Run `bin/flink-suite.sh diagnostic` to include those tests when inspecting plan
 coverage; their `Calc` versus `NativeCalc`-style diffs are diagnostic output, not result-parity bugs.
 
+## Installation audit and exit status
+
+The suite agent targets the pinned release's `DefaultPlannerFactory` and `DelegatePlannerFactory`
+and checks that they declare the expected `create(Context)` method. Transformation records are kept per
+classloader. A successful return from `NativePlanner.install` is recorded for that table
+configuration; entering factory advice alone is not sufficient. An independent constructor check
+requires each eligible streaming table environment to have completed installation. Batch/automatic
+mode and the existing unmodified JSON-plan/test exclusions remain exempt. Merely loading a valid
+factory without creating an environment is allowed. Unknown factory implementations are not
+automatically supported: an eligible environment created without installation fails the audit.
+
+Instrumentation failures, caught installation errors, and eligible environments without installation
+remain fatal even if another configuration or classloader succeeds later. This proves installation,
+not that every query used a native operator; ordinary planner fallback still applies. The audit
+relies on the supported factory methods and table-environment constructor contract remaining visible.
+Changes to both observation points require new compatibility validation.
+
+Each runner invocation uses a fresh audit directory. Each agent JVM writes a `.pending` receipt
+at startup and replaces it with `.ok` or `.failed` at shutdown; failed audits exit with code 70.
+A late audit failure invalidates a prior success receipt and terminates the JVM. The runner
+rejects missing, failed, or incomplete receipts and Surefire dump files. It never turns
+a nonzero Maven exit into success because the test XML looks clean. Surefire's test-failure-ignore
+option lets the XML summarizer apply the named expected-failure allowlist without suppressing
+unexpected assertions/errors; fork failures, dumps, and incomplete audit receipts remain failures.
+Receipts are retained beneath `.flink-suite/audit-<mode>.*` for diagnosis.
+
+PR CI packages the agent and runs three real Surefire 3.2.2 process regressions through the
+launcher: an abnormal exit after passing XML and a successful audit, an abort before audit
+completion, and an allowlisted assertion failure. No Rust build or MiniCluster is required.
+
+```sh
+mvn -f dev/flink-suite/agent/pom.xml clean package
+python3 -m unittest discover -s dev/flink-suite -p 'test_fork_exit.py'
+```
+
+These regressions test exit propagation, not the full Flink installation path. Use the upstream
+integration suite to validate the supported planner hooks. Temporary projects and reports are
+isolated; released Maven dependencies share the normal local cache.
+
 The checkout is cached between runs. Set `FLINK_SUITE_ROOT` to put it elsewhere, or tune local test
 parallelism with `FLINK_SUITE_UNIT_FORKS` and `FLINK_SUITE_IT_FORKS`. The runner uses only public
 artifact repositories, independent of developer-specific Maven mirrors. `FLINK_VERSION` is pinned by


### PR DESCRIPTION
The upstream-suite harness installs StreamFusion by matching Flink classes by name at load time. A miss has always been silent: the suite runs stock Flink end to end, reports every test green, and proves nothing.

That is tolerable while one Flink release is targeted and the names are known good. It becomes actively misleading the moment the suite runs against more than one line, where a renamed or relocated injection point is exactly the failure being looked for — precisely the case where a false green is most expensive.

The agent now records whether the injection point was instrumented and whether it was actually entered, then aborts at shutdown if Flink's planner factory was loaded without it. A run that never installed the engine fails loudly instead of passing.

## Testing

The agent module compiles clean. What this guards is a property of a whole upstream-suite run rather than a unit-testable surface, so it is verified by the suites continuing to pass with the engine installed — not by an added test.
